### PR TITLE
Verb obj updates

### DIFF
--- a/not-to-release/dependencies/sd_780.conllu
+++ b/not-to-release/dependencies/sd_780.conllu
@@ -169,7 +169,7 @@
 25	ته	ته	SCONJ	_	_	28	mark	_	_
 26	گيج	گيج	NOUN	_	_	28	obl	_	_
 27	نه	نه	PART	_	_	28	advmod	_	_
-28	لڙهيا	لڙه	VERB	_	_	10	obj	_	_
+28	لڙهيا	لڙه	VERB	_	_	10	advcl	_	_
 29	هئا	هئو	AUX	_	_	28	aux	_	_
 30	۽	۽	CCONJ	_	_	36	cc	_	_
 31	نه	نه	PART	_	_	36	dep	_	_
@@ -2364,7 +2364,7 @@
 15	ته	ته	SCONJ	_	_	18	mark	_	_
 16	ڇا	ڇا	PRON	_	_	18	obl	_	_
 17	پارليامينٽ	پارليامينٽ	NOUN	_	_	18	nsubj	_	_
-18	چاهي	چاه	VERB	_	_	13	obj	_	_
+18	چاهي	چاه	VERB	_	_	13	advcl	_	_
 19	ٿي	آهي	AUX	_	_	18	aux	_	_
 20	ته	ته	SCONJ	_	_	30	mark	_	_
 21	سندن	سندو	PRON	_	_	22	obl	_	_
@@ -2796,7 +2796,7 @@
 19	آئين	آئين	NOUN	_	_	22	obl	_	_
 20	۾	۾	ADP	_	_	19	case	_	_
 21	شامل	شامل	NOUN	_	_	22	xcomp	_	_
-22	هجي	هجي	VERB	_	_	4	obj	_	_
+22	هجي	هجي	VERB	_	_	4	advcl	_	_
 23	ها	ها	AUX	_	_	22	aux	_	_
 24	،	،	PUNCT	_	_	22	punct	_	_
 
@@ -2952,7 +2952,7 @@
 20	کي	کي	ADP	_	_	19	case	_	_
 21	ڪالعدم	ڪالعدم	NOUN	_	_	23	acl	_	_
 22	قرار	قرار	NOUN	_	_	23	xcomp	_	_
-23	ڏئي	ڏئي	VERB	_	_	4	obj	_	_
+23	ڏئي	ڏئي	VERB	_	_	4	advcl	_	_
 24	سگهي	سگهي	AUX	_	_	23	aux	_	_
 25	ٿي	آهي	AUX	_	_	23	aux	_	_
 26	،	،	PUNCT	_	_	23	punct	_	_
@@ -4965,7 +4965,7 @@
 16	ڇڏي	ڇڏ	VERB	_	_	19	advcl	_	_
 17	پرڏيهه	پرڏيهه	NOUN	_	_	18	nmod	_	_
 18	دورا	دورو	NOUN	_	_	19	obj	_	_
-19	ڪري	ڪر	VERB	_	_	2	obj	_	_
+19	ڪري	ڪر	VERB	_	_	2	advcl	_	_
 20	رهيو	رهيو	VERB	_	_	19	compound	_	_
 21	آهي	آهي	AUX	_	_	19	aux	_	_
 22	،	،	PUNCT	_	_	19	punct	_	_
@@ -6494,7 +6494,7 @@
 17	بس	بس	NOUN	_	_	20	advmod	_	_
 18	اجهو	اجهو	ADV	_	_	20	advmod	_	_
 19	ٿو	آهي	AUX	_	_	20	aux	_	_
-20	پورو	پورو	VERB	_	_	14	obj	_	_
+20	پورو	پورو	VERB	_	_	14	advcl	_	_
 21	ڪريانس	ڪري	VERB	_	_	14	obj	_	_
 22	،	،	PUNCT	_	_	20	punct	_	_
 
@@ -11138,7 +11138,7 @@
 12	انهيءَ	ان	DET	_	_	13	det	_	_
 13	گدڙ	گدڙ	NOUN	_	_	15	obj	_	_
 14	کي	کي	ADP	_	_	13	case	_	_
-15	ڏسان	ڏس	VERB	_	_	7	obj	_	_
+15	ڏسان	ڏس	VERB	_	_	7	advcl	_	_
 16	آءٌ	آءٌ	PRON	_	_	17	nsubj	_	_
 17	چوانس	چو	VERB	_	_	7	obj	_	_
 18	ٿو	آهي	AUX	_	_	17	aux	_	_

--- a/not-to-release/dependencies/sd_batch_2_1000.conllu
+++ b/not-to-release/dependencies/sd_batch_2_1000.conllu
@@ -338,7 +338,7 @@
 12	راجا	راجا	NOUN	_	_	13	nmod	_	_
 13	سوتون	سوت	NOUN	_	_	15	nsubj	_	_
 14	ڪيانگان	_	NOUN	_	_	15	obl	_	_
-15	پهچي	پهچ	VERB	_	_	9	obj	_	_
+15	پهچي	پهچ	VERB	_	_	9	advcl	_	_
 16	ويو	ويو	VERB	_	_	15	compound	_	_
 17	آهي	آهي	AUX	_	_	15	aux	_	SpaceAfter=No
 18	.	.	PUNCT	_	_	15	punct	_	_
@@ -3571,7 +3571,7 @@
 11	مون	مون	PRON	_	_	14	obj	_	_
 12	کي	کي	ADP	_	_	11	case	_	_
 13	ڪائوتان	_	NOUN	_	_	14	xcomp	_	_
-14	سمجهيو	سمجهيو	VERB	_	_	4	obj	_	_
+14	سمجهيو	سمجهيو	VERB	_	_	4	advcl	_	_
 15	آهي	آهي	AUX	_	_	14	aux	_	SpaceAfter=No
 16	،	،	PUNCT	_	_	14	punct	_	_
 
@@ -7075,7 +7075,7 @@
 7	گڏجي	گڏ	ADV	_	_	10	advmod	_	_
 8	سفر	سفر	NOUN	_	_	10	compound	_	_
 9	نٿا	نٿو	ADV	_	_	10	advmod	_	_
-10	ڪري	ڪر	VERB	_	_	2	obj	_	_
+10	ڪري	ڪر	VERB	_	_	2	advcl	_	_
 11	سگهون	_	AUX	_	_	10	aux	_	SpaceAfter=No
 12	.	.	PUNCT	_	_	10	punct	_	_
 
@@ -7901,13 +7901,13 @@
 20	جيڪڏهن	جيڪڏهن	ADP	_	_	23	mark	_	_
 21	علاج	علاج	NOUN	_	_	23	obj	_	_
 22	نه	نه	PART	_	_	23	dep	_	_
-23	ڪيو	ڪيو	VERB	_	_	17	obj	_	_
+23	ڪيو	ڪيو	VERB	_	_	17	advcl	_	_
 24	ته	ته	SCONJ	_	_	29	mark	_	_
 25	توکي	تو	PRON	_	_	29	obj	_	_
 26	موت	موت	NOUN	_	_	28	nmod	_	_
 27	جي	جي	ADP	_	_	28	case	_	_
 28	سزا	_	NOUN	_	_	29	compound	_	_
-29	ڏني	ڏني	VERB	_	_	17	obj	_	_
+29	ڏني	ڏني	VERB	_	_	17	advcl	_	_
 30	ويندي	ويندو	VERB	_	_	29	aux	_	SpaceAfter=No
 31	.	.	PUNCT	_	_	29	punct	_	_
 
@@ -8622,7 +8622,7 @@
 14	ڪانگ	ڪانگ	NOUN	_	_	17	nsubj	_	_
 15	چرچو	_	NOUN	_	_	16	compound	_	_
 16	پيو	پيو	VERB	_	_	17	xcomp	_	_
-17	ڪري	ڪر	VERB	_	_	11	obj	_	SpaceAfter=No
+17	ڪري	ڪر	VERB	_	_	11	advcl	_	SpaceAfter=No
 18	.	.	PUNCT	_	_	17	punct	_	_
 
 # sent_id = 2197
@@ -8781,7 +8781,7 @@
 6	تون	تون	PRON	_	_	9	nsubj	_	_
 7	ڪِن	ڪو	PRON	_	_	8	nmod	_	_
 8	ڪچرو	_	NOUN	_	_	9	xcomp	_	_
-9	کائيندو	_	VERB	_	_	3	obj	_	_
+9	کائيندو	_	VERB	_	_	3	advcl	_	_
 10	رهندو	ره	VERB	_	_	9	compound	_	_
 11	آهين	آهي	AUX	_	_	9	aux	_	SpaceAfter=No
 12	.	.	PUNCT	_	_	9	punct	_	_
@@ -9071,7 +9071,7 @@
 16	تي	تي	ADP	_	_	17	mark	_	_
 17	رک	_	VERB	_	_	9	obj	_	_
 18	ته	ته	SCONJ	_	_	19	mark	_	_
-19	کڻي	کڻي	VERB	_	_	9	obj	_	_
+19	کڻي	کڻي	VERB	_	_	9	advcl	_	_
 20	وڃان	وڃ	VERB	_	_	19	compound	_	SpaceAfter=No
 21	.	.	PUNCT	_	_	19	punct	_	_
 
@@ -10130,7 +10130,7 @@
 10	گدڙ	گدڙ	NOUN	_	_	13	obj	_	_
 11	کي	کي	ADP	_	_	10	case	_	_
 12	به	به	PART	_	_	13	mark	_	_
-13	کڻندو	_	VERB	_	_	2	obj	_	_
+13	کڻندو	_	VERB	_	_	2	advcl	_	_
 14	آهي	آهي	AUX	_	_	13	aux	_	SpaceAfter=No
 15	،	،	PUNCT	_	_	13	punct	_	_
 
@@ -10676,7 +10676,7 @@
 24	پڇ	پڇ	NOUN	_	_	26	obl	_	_
 25	سان	سان	ADP	_	_	26	mark	_	_
 26	ڇڪي	ڇڪ	VERB	_	_	27	xcomp	_	_
-27	ٻڌل	ٻڌ	VERB	_	_	17	obj	_	_
+27	ٻڌل	ٻڌ	VERB	_	_	17	advcl	_	_
 28	آهي	آهي	AUX	_	_	27	aux	_	SpaceAfter=No
 29	.	.	PUNCT	_	_	27	punct	_	_
 
@@ -11496,7 +11496,7 @@
 5	پرانهين	_	ADJ	_	_	6	nmod	_	_
 6	ملڪ	ملڪ	NOUN	_	_	8	obl	_	_
 7	مان	مان	ADP	_	_	8	mark	_	_
-8	آيو	آءَ	VERB	_	_	1	obj	_	_
+8	آيو	آءَ	VERB	_	_	1	advcl	_	_
 9	آهين	آهي	AUX	_	_	8	aux	_	SpaceAfter=No
 10	.	.	PUNCT	_	_	8	punct	_	_
 
@@ -11662,7 +11662,7 @@
 27	ماني	ماني	NOUN	_	_	28	nmod	_	_
 28	ڀور	_	NOUN	_	_	30	obj	_	_
 29	ته	ته	PART	_	_	28	advmod:emph	_	_
-30	ملي	مل	VERB	_	_	4	obj	_	_
+30	ملي	مل	VERB	_	_	4	advcl	_	_
 31	ويندو	ويندو	VERB	_	_	30	compound	_	SpaceAfter=No
 32	،	،	PUNCT	_	_	30	punct	_	_
 
@@ -14406,7 +14406,7 @@
 16	سان	سان	ADP	_	_	15	case	_	_
 17	گڏ	گڏ	ADV	_	_	19	advmod	_	_
 18	اتي	اتي	ADV	_	_	19	advmod	_	_
-19	رهندو	ره	VERB	_	_	2	obj	_	_
+19	رهندو	ره	VERB	_	_	2	advcl	_	_
 20	هو	هو	AUX	_	_	19	aux	_	SpaceAfter=No
 21	.	.	PUNCT	_	_	19	punct	_	_
 
@@ -14696,7 +14696,7 @@
 8	مڪسل	_	NOUN	_	_	11	nsubj	_	_
 9	اتي	اتي	ADV	_	_	10	advmod	_	_
 10	اچي	اچ	VERB	_	_	11	xcomp	_	_
-11	سمهندو	_	VERB	_	_	1	obj	_	_
+11	سمهندو	_	VERB	_	_	1	advcl	_	_
 12	آهي	آهي	AUX	_	_	11	aux	_	SpaceAfter=No
 13	.	.	PUNCT	_	_	11	punct	_	_
 
@@ -17048,7 +17048,7 @@
 18	اهو	اهو	DET	_	_	19	det	_	_
 19	بل	بل	NOUN	_	_	21	obj	_	_
 20	پيش	پيش	VERB	_	_	21	compound	_	_
-21	ڪيو	ڪيو	VERB	_	_	5	obj	_	_
+21	ڪيو	ڪيو	VERB	_	_	5	advcl	_	_
 22	ويندو	ويندو	VERB	_	_	21	compound	_	SpaceAfter=No
 23	.	.	PUNCT	_	_	21	punct	_	_
 
@@ -17617,7 +17617,7 @@
 19	ڳوٺن	ڳوٺ	NOUN	_	_	22	obj	_	_
 20	کي	کي	ADP	_	_	22	obj	_	_
 21	پڪو	_	ADJ	_	_	22	compound	_	_
-22	ڪيو	ڪيو	VERB	_	_	14	obj	_	_
+22	ڪيو	ڪيو	VERB	_	_	14	advcl	_	_
 23	ويندو	ويندو	VERB	_	_	22	compound	_	SpaceAfter=No
 24	،	،	PUNCT	_	_	22	punct	_	_
 

--- a/not-to-release/dependencies/sd_batch_3.conllu
+++ b/not-to-release/dependencies/sd_batch_3.conllu
@@ -98,7 +98,7 @@
 12	عوامي	عوامي	ADJ	_	_	13	nmod	_	_
 13	سمنڊ	سمنڊ	NOUN	_	_	15	obl	_	_
 14	۾	۾	ADP	_	_	13	case	_	_
-15	لڙهي	لڙه	VERB	_	_	7	obj	_	_
+15	لڙهي	لڙه	VERB	_	_	7	advcl	_	_
 16	ويندا	ويندو	VERB	_	_	15	compound	_	SpaceAfter=No
 17	،	،	PUNCT	_	_	15	punct	_	_
 
@@ -343,7 +343,7 @@
 23	سياستدانن	سياست	NOUN	_	_	25	nmod	_	_
 24	جو	جو	ADP	_	_	23	case	_	_
 25	احتساب	احتساب	NOUN	_	_	26	xcomp	_	_
-26	ٿيڻو	ٿي	VERB	_	_	17	obj	_	_
+26	ٿيڻو	ٿي	VERB	_	_	17	advcl	_	_
 27	آهي	آهي	AUX	_	_	26	aux	_	_
 28	ته	ته	SCONJ	_	_	36	mark	_	_
 29	پوءِ	پوءِ	ADP	_	_	26	mark	_	_
@@ -556,7 +556,7 @@
 17	کانسواءِ	کان	ADP	_	_	16	case	_	_
 18	اقتدار	اقتدار	NOUN	_	_	20	obl	_	_
 19	۾	۾	ADP	_	_	18	case	_	_
-20	آئي	آئي	VERB	_	_	2	obj	_	_
+20	آئي	آئي	VERB	_	_	2	advcl	_	_
 21	آهي	آهي	AUX	_	_	20	aux	_	SpaceAfter=No
 22	،	،	PUNCT	_	_	20	punct	_	_
 
@@ -1457,7 +1457,7 @@
 35	صحافين	صحافي	NOUN	_	_	38	obl	_	_
 36	کان	کان	ADP	_	_	35	case	_	_
 37	معافي	_	NOUN	_	_	38	compound	_	_
-38	ورتي	ورتي	VERB	_	_	16	obj	_	_
+38	ورتي	ورتي	VERB	_	_	16	advcl	_	_
 39	وئي	وئي	VERB	_	_	38	compound	_	_
 40	آهي	آهي	AUX	_	_	38	aux	_	_
 41	۽	۽	CCONJ	_	_	51	cc	_	_
@@ -1622,7 +1622,7 @@
 12	اقتدار	اقتدار	NOUN	_	_	15	obl	_	_
 13	۾	۾	ADP	_	_	15	obl	_	_
 14	ناهي	ناهي	AUX	_	_	15	aux	_	_
-15	آئي	آئي	VERB	_	_	4	obj	_	SpaceAfter=No
+15	آئي	آئي	VERB	_	_	4	advcl	_	SpaceAfter=No
 16	،	،	PUNCT	_	_	15	punct	_	_
 17	عوام	عوام	NOUN	_	_	25	nsubj	_	_
 18	پيپلز	پيپلز	NOUN	_	_	19	compound	_	_
@@ -2169,7 +2169,7 @@
 14	ڌار	_	ADJ	_	_	15	compound	_	_
 15	ڌار	_	NOUN	_	_	17	obl	_	_
 16	دبئي	_	NOUN	_	_	17	obl	_	_
-17	پهتا	پهتو	VERB	_	_	6	obj	_	SpaceAfter=No
+17	پهتا	پهتو	VERB	_	_	6	advcl	_	SpaceAfter=No
 18	،	،	PUNCT	_	_	17	punct	_	_
 19	اتان	اتي	ADV	_	_	25	advmod	_	_
 20	وري	وري	ADV	_	_	25	advmod	_	_
@@ -2754,7 +2754,7 @@
 55	جي	جي	ADP	_	_	54	case	_	_
 56	ڏينهن	ڏينهن	NOUN	_	_	58	obl	_	_
 57	بند	بند	NOUN	_	_	58	xcomp	_	_
-58	ڪيو	ڪيو	VERB	_	_	36	obj	_	_
+58	ڪيو	ڪيو	VERB	_	_	36	advcl	_	_
 59	ويو	ويو	VERB	_	_	58	compound	_	_
 60	آهي	آهي	AUX	_	_	58	aux	_	_
 61	بهرحال	بهرحال	ADV	_	_	66	advmod	_	_
@@ -2768,7 +2768,7 @@
 69	سفارتخانو	_	NOUN	_	_	72	nsubj	_	_
 70	ڪيستائين	_	ADV	_	_	72	obl	_	_
 71	بند	بند	NOUN	_	_	72	compound	_	_
-72	رهندو	ره	VERB	_	_	66	obj	_	SpaceAfter=No
+72	رهندو	ره	VERB	_	_	66	advcl	_	SpaceAfter=No
 73	.	.	PUNCT	_	_	72	punct	_	_
 
 # sent_id = 3805
@@ -3508,7 +3508,7 @@
 18	ختم	ختم	ADJ	_	_	21	compound	_	_
 19	نه	نه	PART	_	_	21	dep	_	_
 20	ٿيون	ٿي	VERB	_	_	21	compound	_	_
-21	ڪري	ڪر	VERB	_	_	4	obj	_	_
+21	ڪري	ڪر	VERB	_	_	4	advcl	_	_
 22	سگهن	سگهي	AUX	_	_	21	aux	_	SpaceAfter=No
 23	.	.	PUNCT	_	_	21	punct	_	_
 
@@ -3769,7 +3769,7 @@
 11	کان	کان	ADP	_	_	10	mark	_	_
 12	اڳ	اڳ	NOUN	_	_	14	obl	_	_
 13	شهيد	_	ADJ	_	_	14	xcomp	_	_
-14	ٿي	آهي	VERB	_	_	4	obj	_	_
+14	ٿي	آهي	VERB	_	_	4	advcl	_	_
 15	چڪي	چڪو	VERB	_	_	14	compound	_	_
 16	هئي	آهي	AUX	_	_	14	aux	_	SpaceAfter=No
 17	،	،	PUNCT	_	_	14	punct	_	_
@@ -5280,7 +5280,7 @@
 9	ته	ته	SCONJ	_	_	12	mark	_	_
 10	گهڻو	گهڻو	ADJ	_	_	11	amod	_	_
 11	ڪجهه	ڪجهه	ADJ	_	_	12	nsubj	_	_
-12	لڪيل	_	VERB	_	_	6	obj	_	_
+12	لڪيل	_	VERB	_	_	6	advcl	_	_
 13	ڪونهي	آهي	VERB	_	_	12	compound	_	SpaceAfter=No
 14	.	.	PUNCT	_	_	12	punct	_	_
 
@@ -5791,7 +5791,7 @@
 12	ته	ته	SCONJ	_	_	15	mark	_	_
 13	ٻاهر	ٻاهر	ADV	_	_	15	advmod	_	_
 14	ئي	ئي	PART	_	_	13	advmod:emph	_	_
-15	ويٺا	ويٺو	VERB	_	_	2	obj	_	_
+15	ويٺا	ويٺو	VERB	_	_	2	advcl	_	_
 16	هجن	هجي	VERB	_	_	15	compound	_	SpaceAfter=No
 17	،	،	PUNCT	_	_	15	punct	_	_
 
@@ -7885,7 +7885,7 @@
 16	تي	تي	ADP	_	_	15	case	_	_
 17	عراق	_	NOUN	_	_	18	obl	_	_
 18	ڇو	_	VERB	_	_	19	xcomp	_	_
-19	ويا	ويو	VERB	_	_	4	obj	_	_
+19	ويا	ويو	VERB	_	_	4	advcl	_	_
 20	هئا	هئو	AUX	_	_	19	aux	_	SpaceAfter=No
 21	.	.	PUNCT	_	_	19	punct	_	_
 
@@ -8093,7 +8093,7 @@
 10	سان	سان	ADP	_	_	9	case	_	_
 11	ٽارگيٽ	ٽارگيٽ	NOUN	_	_	13	obj	_	_
 12	حاصل	حاصل	NOUN	_	_	13	compound	_	_
-13	ٿئي	ٿي	VERB	_	_	4	obj	_	_
+13	ٿئي	ٿي	VERB	_	_	4	advcl	_	_
 14	يا	يا	CCONJ	_	_	16	cc	_	_
 15	نه	نه	PART	_	_	16	dep	_	_
 16	ٿئي	ٿي	VERB	_	_	13	conj	_	_
@@ -9404,7 +9404,7 @@
 25	به	به	PART	_	_	24	advmod:emph	_	_
 26	حاوي	_	ADJ	_	_	28	compound	_	_
 27	نه	نه	PART	_	_	28	dep	_	_
-28	ٿيندو	آهي	VERB	_	_	18	obj	_	SpaceAfter=No
+28	ٿيندو	آهي	VERB	_	_	18	advcl	_	SpaceAfter=No
 29	.	.	PUNCT	_	_	28	punct	_	_
 
 # sent_id = 4125
@@ -10202,7 +10202,7 @@
 5	جي	جي	ADP	_	_	4	case	_	_
 6	دنيا	دنيا	NOUN	_	_	8	nsubj	_	_
 7	تبديل	تبديل	NOUN	_	_	8	compound	_	_
-8	ٿيڻي	_	VERB	_	_	1	obj	_	_
+8	ٿيڻي	_	VERB	_	_	1	advcl	_	_
 9	ناهي	ناهي	AUX	_	_	8	aux	_	SpaceAfter=No
 10	،	،	PUNCT	_	_	8	punct	_	_
 
@@ -11813,7 +11813,7 @@
 10	هئڻ	هئو	VERB	_	_	12	nmod	_	_
 11	جو	جو	ADP	_	_	10	mark	_	_
 12	گمان	گمان	NOUN	_	_	13	compound	_	_
-13	ٿئي	ٿي	VERB	_	_	3	obj	_	_
+13	ٿئي	ٿي	VERB	_	_	3	advcl	_	_
 14	ٿو	آهي	AUX	_	_	13	aux	_	SpaceAfter=No
 15	.	.	PUNCT	_	_	13	punct	_	_
 
@@ -12506,7 +12506,7 @@
 7	ڪتابن	ڪتاب	NOUN	_	_	9	nmod	_	_
 8	جا	جو	ADP	_	_	7	case	_	_
 9	ترجما	_	NOUN	_	_	10	obj	_	_
-10	ڪيا	ڪيو	VERB	_	_	3	obj	_	_
+10	ڪيا	ڪيو	VERB	_	_	3	advcl	_	_
 11	ويندا	ويندو	VERB	_	_	10	compound	_	_
 12	آهن	آهي	AUX	_	_	10	aux	_	SpaceAfter=No
 13	،	،	PUNCT	_	_	10	punct	_	_
@@ -13098,7 +13098,7 @@
 9	کي	کي	ADP	_	_	8	case	_	_
 10	مالا	_	NOUN	_	_	12	obj	_	_
 11	مال	مال	NOUN	_	_	12	compound	_	_
-12	ڪري	ڪر	VERB	_	_	4	obj	_	_
+12	ڪري	ڪر	VERB	_	_	4	advcl	_	_
 13	ٿو	آهي	AUX	_	_	12	aux	_	SpaceAfter=No
 14	،	،	PUNCT	_	_	12	punct	_	_
 
@@ -13119,7 +13119,7 @@
 13	کي	کي	ADP	_	_	12	case	_	_
 14	عزت	عزت	NOUN	_	_	15	nmod	_	_
 15	دار	دار	NOUN	_	_	16	xcomp	_	_
-16	بنايون	بنائي	VERB	_	_	6	obj	_	_
+16	بنايون	بنائي	VERB	_	_	6	advcl	_	_
 17	۽	۽	CCONJ	_	_	25	cc	_	_
 18	کيس	کي	ADP	_	_	25	nsubj	_	_
 19	ماني	ماني	NOUN	_	_	20	nmod	_	_
@@ -15351,7 +15351,7 @@
 14	ڍءُ	ڍءُ	NOUN	_	_	15	obj	_	_
 15	جهليو	_	VERB	_	_	17	xcomp	_	_
 16	نٿو	نٿو	PART	_	_	17	dep	_	_
-17	ٿئي	ٿي	VERB	_	_	9	obj	_	SpaceAfter=No
+17	ٿئي	ٿي	VERB	_	_	9	advcl	_	SpaceAfter=No
 18	.	.	PUNCT	_	_	17	punct	_	_
 
 # sent_id = 4462

--- a/not-to-release/dependencies/sd_batch_4.800.conllu
+++ b/not-to-release/dependencies/sd_batch_4.800.conllu
@@ -39,7 +39,7 @@
 37	ڏينهن	ڏينهن	NOUN	_	_	40	obl	_	_
 38	اڳ	اڳ	NOUN	_	_	40	obl	_	_
 39	آزاد	آزاد	ADJ	_	_	40	compound	_	_
-40	ڪيو	ڪيو	VERB	_	_	13	obj	_	_
+40	ڪيو	ڪيو	VERB	_	_	13	advcl	_	_
 41	آهي	آهي	AUX	_	_	40	aux	_	SpaceAfter=No
 42	،	،	PUNCT	_	_	40	punct	_	_
 
@@ -880,7 +880,7 @@
 20	جي	جي	ADP	_	_	21	amod	_	_
 21	زراعت	زراعت	NOUN	_	_	23	nsubj	_	_
 22	مضبوط	مضبوط	ADJ	_	_	23	xcomp	_	_
-23	هجي	هجي	VERB	_	_	16	obj	_	_
+23	هجي	هجي	VERB	_	_	16	advcl	_	_
 24	۽	۽	CCONJ	_	_	38	cc	_	_
 25	اهي	اهي	DET	_	_	38	nsubj	_	_
 26	نه	نه	PART	_	_	25	dep	_	_
@@ -1463,7 +1463,7 @@
 16	حساب	حساب	NOUN	_	_	19	obl	_	_
 17	۾	۾	ADP	_	_	16	case	_	_
 18	گهٽ	گهٽ	ADJ	_	_	19	xcomp	_	_
-19	ملي	مل	VERB	_	_	4	obj	_	_
+19	ملي	مل	VERB	_	_	4	advcl	_	_
 20	ٿي	آهي	AUX	_	_	19	aux	_	SpaceAfter=No
 21	.	.	PUNCT	_	_	19	punct	_	_
 
@@ -2131,7 +2131,7 @@
 14	مقدار	مقدار	NOUN	_	_	17	obl	_	_
 15	۾	۾	ADP	_	_	14	case	_	_
 16	پاڻي	پاڻي	NOUN	_	_	17	nsubj	_	_
-17	موجود	_	VERB	_	_	3	obj	_	_
+17	موجود	_	VERB	_	_	3	advcl	_	_
 18	آهي	آهي	AUX	_	_	17	cop	_	_
 19	۽	۽	CCONJ	_	_	28	cc	_	_
 20	هاري	هاري	NOUN	_	_	28	nsubj	_	_
@@ -2389,7 +2389,7 @@
 21	کي	کي	ADP	_	_	20	case	_	_
 22	ليز	ليز	NOUN	_	_	24	obl	_	_
 23	تي	تي	ADP	_	_	22	case	_	_
-24	ڏني	ڏني	VERB	_	_	3	obj	_	_
+24	ڏني	ڏني	VERB	_	_	3	advcl	_	_
 25	وئي	وئي	VERB	_	_	24	compound	_	_
 26	آهي	آهي	AUX	_	_	24	aux	_	SpaceAfter=No
 27	.	.	PUNCT	_	_	24	punct	_	_
@@ -2459,7 +2459,7 @@
 13	جنهن	جنهن	PRON	_	_	14	det	_	_
 14	تيزي	تيزي	NOUN	_	_	16	obl	_	_
 15	سان	سان	ADP	_	_	14	case	_	_
-16	وڌي	وڌي	VERB	_	_	7	obj	_	_
+16	وڌي	وڌي	VERB	_	_	7	advcl	_	_
 17	رهي	ره	VERB	_	_	16	compound	_	_
 18	آهي	آهي	AUX	_	_	16	aux	_	_
 19	ان	ان	DET	_	_	21	nmod	_	_
@@ -2504,7 +2504,7 @@
 20	گدامن	_	NOUN	_	_	23	obj	_	_
 21	کي	کي	ADP	_	_	20	case	_	_
 22	ڀريل	_	VERB	_	_	23	xcomp	_	_
-23	رکو	رک	VERB	_	_	5	obj	_	_
+23	رکو	رک	VERB	_	_	5	advcl	_	_
 24	۽	۽	CCONJ	_	_	33	cc	_	_
 25	ڪيترن	ڪيترو	ADJ	_	_	27	amod	_	_
 26	ئي	ئي	ADP	_	_	25	case	_	_
@@ -3035,7 +3035,7 @@
 23	وڏو	وڏو	ADJ	_	_	25	amod	_	_
 24	معاشي	معاشي	ADJ	_	_	25	amod	_	_
 25	فائدو	فائدو	NOUN	_	_	26	nsubj	_	_
-26	مليو	مل	VERB	_	_	6	obj	_	_
+26	مليو	مل	VERB	_	_	6	advcl	_	_
 27	آهي	آهي	AUX	_	_	26	aux	_	_
 28	يا	يا	CCONJ	_	_	29	cc	_	_
 29	ملندو	_	VERB	_	_	26	conj	_	SpaceAfter=No
@@ -3237,7 +3237,7 @@
 18	بنياد	بنياد	NOUN	_	_	21	obl	_	_
 19	تي	تي	ADP	_	_	18	case	_	_
 20	ممڪن	ممڪن	ADJ	_	_	21	xcomp	_	_
-21	ٿي	آهي	VERB	_	_	5	obj	_	_
+21	ٿي	آهي	VERB	_	_	5	advcl	_	_
 22	سگهندي	سگهندو	AUX	_	_	21	aux	_	_
 23	ته	ته	SCONJ	_	_	21	mark	_	_
 24	گڏوگڏ	گڏ	ADV	_	_	26	advmod	_	_
@@ -5012,7 +5012,7 @@
 28	ڪرڻ	ڪر	VERB	_	_	31	advcl	_	_
 29	کان	کان	ADP	_	_	28	mark	_	_
 30	پاسو	پاسو	NOUN	_	_	31	obl	_	_
-31	ڪيو	ڪيو	VERB	_	_	9	obj	_	_
+31	ڪيو	ڪيو	VERB	_	_	9	advcl	_	_
 32	ويندو	ويندو	VERB	_	_	31	compound	_	_
 33	ڇو	ڇو	PRON	_	_	54	obl	_	_
 34	جو	جو	ADP	_	_	33	mark	_	_
@@ -6116,7 +6116,7 @@
 17	حلّوس	حلّوس	NOUN	_	_	20	obl	_	_
 18	لاءِ	لاءِ	ADP	_	_	17	case	_	_
 19	مقرر	مقرر	NOUN	_	_	20	xcomp	_	_
-20	ڪيا	ڪيو	VERB	_	_	7	obj	_	_
+20	ڪيا	ڪيو	VERB	_	_	7	advcl	_	_
 21	هئا	هئو	AUX	_	_	20	aux	_	_
 22	۽	۽	CCONJ	_	_	37	cc	_	_
 23	شهرن	شهر	NOUN	_	_	27	nmod	_	_
@@ -6609,7 +6609,7 @@
 12	هر	هر	DET	_	_	13	det	_	_
 13	صوبي	صوبي	NOUN	_	_	15	obl	_	_
 14	۾	۾	ADP	_	_	13	case	_	_
-15	ٿين	آھي	VERB	_	_	6	obj	_	_
+15	ٿين	آھي	VERB	_	_	6	advcl	_	_
 16	ٿا	آهي	AUX	_	_	15	aux	_	_
 17	پر	پر	SCONJ	_	_	15	mark	_	_
 18	اهڙا	اهڙو	ADJ	_	_	19	amod	_	_
@@ -6688,7 +6688,7 @@
 8	فيصد	_	NOUN	_	_	9	nmod	_	_
 9	ٽيڪس	_	NOUN	_	_	11	obj	_	_
 10	تا	_	ADP	_	_	11	xcomp	_	_
-11	ڏيون	_	VERB	_	_	3	obj	_	_
+11	ڏيون	_	VERB	_	_	3	advcl	_	_
 12	ته	ته	SCONJ	_	_	11	mark	_	_
 13	پوءِ	پوءِ	ADP	_	_	11	mark	_	_
 14	اسان	اسين	PRON	_	_	16	nmod	_	_
@@ -8217,7 +8217,7 @@
 24	پر	پر	SCONJ	_	_	25	dep	_	_
 25	دهشتگردن	دهشتگرد	NOUN	_	_	27	obl	_	_
 26	خلاف	خلاف	ADP	_	_	25	case	_	_
-27	ٿي	آهي	VERB	_	_	12	obj	_	_
+27	ٿي	آهي	VERB	_	_	12	advcl	_	_
 28	رهيو	رهيو	VERB	_	_	27	compound	_	_
 29	آهي	آهي	AUX	_	_	27	aux	_	SpaceAfter=No
 30	،	،	PUNCT	_	_	27	punct	_	_
@@ -8561,7 +8561,7 @@
 30	تيزي	تيزي	NOUN	_	_	33	obl	_	_
 31	سان	سان	ADP	_	_	30	case	_	_
 32	اڳتي	اڳتي	ADV	_	_	33	advmod	_	_
-33	وڌي	وڌي	VERB	_	_	22	obj	_	_
+33	وڌي	وڌي	VERB	_	_	22	advcl	_	_
 34	رهي	ره	VERB	_	_	33	compound	_	_
 35	آهي	آهي	AUX	_	_	33	aux	_	SpaceAfter=No
 36	،	،	PUNCT	_	_	33	punct	_	_
@@ -9370,7 +9370,7 @@
 29	جذبا	_	NOUN	_	_	30	obj	_	_
 30	کڻي	کڻي	VERB	_	_	32	advcl	_	_
 31	پاڪستان	پاڪستان	PROPN	_	_	32	obl	_	_
-32	آئي	آئي	VERB	_	_	23	obj	_	_
+32	آئي	آئي	VERB	_	_	23	advcl	_	_
 33	۽	۽	CCONJ	_	_	40	cc	_	_
 34	اوباما	اوباما	PROPN	_	_	37	nmod	_	_
 35	جا	جو	ADP	_	_	34	case	_	_
@@ -9659,7 +9659,7 @@
 22	بدنامي	بدنامي	NOUN	_	_	24	nmod	_	_
 23	جو	جو	ADP	_	_	22	case	_	_
 24	سبب	سبب	NOUN	_	_	25	xcomp	_	_
-25	هوندو	هوندو	VERB	_	_	8	obj	_	_
+25	هوندو	هوندو	VERB	_	_	8	advcl	_	_
 26	پر	پر	SCONJ	_	_	25	mark	_	_
 27	اسان	اسين	PRON	_	_	30	nmod	_	_
 28	جي	جي	ADP	_	_	27	case	_	_
@@ -9841,7 +9841,7 @@
 27	مون	مون	PRON	_	_	30	obl	_	_
 28	مٿان	مٿي	ADV	_	_	30	advmod	_	_
 29	تنقيد	تنقيد	NOUN	_	_	30	xcomp	_	_
-30	ڪئي	ڪئي	VERB	_	_	16	obj	_	_
+30	ڪئي	ڪئي	VERB	_	_	16	advcl	_	_
 31	۽	۽	CCONJ	_	_	32	cc	_	_
 32	چيو	چئو	VERB	_	_	30	conj	_	_
 33	ويو	ويو	VERB	_	_	32	compound	_	_
@@ -9854,7 +9854,7 @@
 40	شريف	شريف	NOUN	_	_	42	nmod	_	_
 41	جو	جو	ADP	_	_	40	case	_	_
 42	گراف	گراف	NOUN	_	_	43	nsubj	_	_
-43	گهٽجي	گهٽج	VERB	_	_	32	obj	_	_
+43	گهٽجي	گهٽج	VERB	_	_	32	advcl	_	_
 44	ويو	ويو	VERB	_	_	43	compound	_	_
 45	آهي	آهي	AUX	_	_	43	aux	_	SpaceAfter=No
 46	،	،	PUNCT	_	_	43	punct	_	_
@@ -10127,7 +10127,7 @@
 21	پئڪيج	_	NOUN	_	_	23	nmod	_	_
 22	جو	جو	ADP	_	_	21	case	_	_
 23	اعلان	اعلان	NOUN	_	_	24	xcomp	_	_
-24	ڪري	ڪر	VERB	_	_	7	obj	_	_
+24	ڪري	ڪر	VERB	_	_	7	advcl	_	_
 25	وئي	وئي	VERB	_	_	24	compound	_	_
 26	آهي	آهي	AUX	_	_	24	aux	_	SpaceAfter=No
 27	،	،	PUNCT	_	_	24	punct	_	_
@@ -10575,7 +10575,7 @@
 69	مهينا	_	NOUN	_	_	70	nmod	_	_
 70	اڳ	اڳ	NOUN	_	_	72	obj	_	_
 71	تيار	تيار	NOUN	_	_	72	xcomp	_	_
-72	ڪرڻ	ڪر	VERB	_	_	53	obj	_	_
+72	ڪرڻ	ڪر	VERB	_	_	53	advcl	_	_
 73	گهرجن	گهرجي	VERB	_	_	72	compound	_	_
 74	ته	ته	SCONJ	_	_	72	mark	_	_
 75	جيئن	جيئن	ADV	_	_	72	mark	_	_
@@ -11106,7 +11106,7 @@
 12	مليل	مليو	VERB	_	_	13	acl	_	_
 13	رپورٽن	_	NOUN	_	_	15	obl	_	_
 14	۾	۾	ADP	_	_	13	case	_	_
-15	چيو	چئو	VERB	_	_	3	obj	_	_
+15	چيو	چئو	VERB	_	_	3	advcl	_	_
 16	ويو	ويو	VERB	_	_	15	compound	_	_
 17	آهي	آهي	AUX	_	_	15	aux	_	_
 18	ته	ته	SCONJ	_	_	34	mark	_	_
@@ -11125,7 +11125,7 @@
 31	حملا	حملو	NOUN	_	_	32	compound	_	_
 32	ڪرڻ	ڪر	VERB	_	_	34	advcl	_	_
 33	طرف	طرف	NOUN	_	_	34	obl	_	_
-34	وڌائي	وڌاءِ	VERB	_	_	15	obj	_	_
+34	وڌائي	وڌاءِ	VERB	_	_	15	advcl	_	_
 35	رهيا	ره	VERB	_	_	34	compound	_	_
 36	آهن	آهي	AUX	_	_	34	aux	_	SpaceAfter=No
 37	،	،	PUNCT	_	_	34	punct	_	_
@@ -11234,7 +11234,7 @@
 16	مقصدن	_	NOUN	_	_	19	obl	_	_
 17	لاءِ	لاءِ	ADP	_	_	16	case	_	_
 18	استعمال	استعمال	NOUN	_	_	19	compound	_	_
-19	ڪري	ڪر	VERB	_	_	3	obj	_	_
+19	ڪري	ڪر	VERB	_	_	3	advcl	_	_
 20	سگهن	سگهي	AUX	_	_	19	aux	_	_
 21	ٿيون	ٿي	AUX	_	_	19	aux	_	SpaceAfter=No
 22	.	.	PUNCT	_	_	19	punct	_	_
@@ -11613,7 +11613,7 @@
 20	ڪرڻ	ڪر	VERB	_	_	22	nmod	_	_
 21	جي	جي	ADP	_	_	20	mark	_	_
 22	رٿابندي	_	NOUN	_	_	23	obl	_	_
-23	ڪري	ڪر	VERB	_	_	8	obj	_	_
+23	ڪري	ڪر	VERB	_	_	8	advcl	_	_
 24	رهيا	ره	VERB	_	_	23	compound	_	_
 25	هئا	هئو	AUX	_	_	23	aux	_	SpaceAfter=No
 26	.	.	PUNCT	_	_	23	punct	_	_
@@ -12174,7 +12174,7 @@
 64	اختيار	اختيار	NOUN	_	_	67	obj	_	_
 65	بحال	_	NOUN	_	_	67	xcomp	_	_
 66	نه	نه	PART	_	_	67	dep	_	_
-67	ٿيا	ٿيو	VERB	_	_	56	obj	_	_
+67	ٿيا	ٿيو	VERB	_	_	56	advcl	_	_
 68	آهن	آهي	AUX	_	_	67	aux	_	SpaceAfter=No
 69	.	.	PUNCT	_	_	67	punct	_	_
 
@@ -12390,7 +12390,7 @@
 13	نوٽيفڪيشن	نوٽيفڪيشن	NOUN	_	_	16	obj	_	_
 14	واپس	واپس	VERB	_	_	16	compound	_	_
 15	نٿو	نٿو	PART	_	_	16	dep	_	_
-16	ورتو	ورتو	VERB	_	_	6	obj	_	_
+16	ورتو	ورتو	VERB	_	_	6	advcl	_	_
 17	وڃي	وڃ	VERB	_	_	16	compound	_	SpaceAfter=No
 18	،	،	PUNCT	_	_	16	punct	_	_
 
@@ -12677,7 +12677,7 @@
 25	ڪندي	ڪن	VERB	_	_	28	advcl	_	_
 26	گهٽين	_	NOUN	_	_	28	obl	_	_
 27	۾	۾	ADP	_	_	26	case	_	_
-28	ويندا	ويندو	VERB	_	_	14	obj	_	_
+28	ويندا	ويندو	VERB	_	_	14	advcl	_	_
 29	رهيا	ره	VERB	_	_	28	compound	_	_
 30	جڏهن	جڏهن	ADV	_	_	43	advmod	_	_
 31	ته	ته	SCONJ	_	_	28	mark	_	_
@@ -14404,7 +14404,7 @@
 45	کي	کي	ADP	_	_	44	case	_	_
 46	الڳ	الڳ	ADJ	_	_	48	compound	_	_
 47	ناهي	ناهي	AUX	_	_	48	aux	_	_
-48	ڪيو	ڪيو	VERB	_	_	30	obj	_	SpaceAfter=No
+48	ڪيو	ڪيو	VERB	_	_	30	advcl	_	SpaceAfter=No
 49	،	،	PUNCT	_	_	48	punct	_	_
 
 # sent_id = 5016
@@ -14827,7 +14827,7 @@
 63	کان	کان	ADP	_	_	62	case	_	_
 64	اڳ	اڳ	NOUN	_	_	66	obl	_	_
 65	رقم	رقم	NOUN	_	_	66	obj	_	_
-66	ڏني	ڏني	VERB	_	_	49	obj	_	_
+66	ڏني	ڏني	VERB	_	_	49	advcl	_	_
 67	ويندي	ويندو	VERB	_	_	66	compound	_	SpaceAfter=No
 68	،	،	PUNCT	_	_	66	punct	_	_
 
@@ -15075,7 +15075,7 @@
 35	ميگاواٽ	_	NOUN	_	_	36	nmod	_	_
 36	بجلي	بجلي	NOUN	_	_	38	nsubj	_	_
 37	بچت	بچت	NOUN	_	_	38	compound	_	_
-38	ٿيندي	ٿي	VERB	_	_	24	obj	_	_
+38	ٿيندي	ٿي	VERB	_	_	24	advcl	_	_
 39	هئي	آهي	AUX	_	_	38	aux	_	SpaceAfter=No
 40	،	،	PUNCT	_	_	38	punct	_	_
 
@@ -15191,7 +15191,7 @@
 55	جي	جي	ADP	_	_	54	case	_	_
 56	پاليسي	پاليسي	NOUN	_	_	57	obj	_	_
 57	ٺاهڻ	ٺاه	VERB	_	_	58	xcomp	_	_
-58	چاهي	چاه	VERB	_	_	32	obj	_	_
+58	چاهي	چاه	VERB	_	_	32	advcl	_	_
 59	ٿي	آهي	AUX	_	_	58	aux	_	SpaceAfter=No
 60	،	،	PUNCT	_	_	58	punct	_	_
 
@@ -15550,7 +15550,7 @@
 9	عدالت	عدالت	NOUN	_	_	12	obl	_	_
 10	۾	۾	ADP	_	_	9	case	_	_
 11	چيلينج	چيلينج	NOUN	_	_	12	xcomp	_	_
-12	ٿيل	ٿيو	VERB	_	_	1	obj	_	_
+12	ٿيل	ٿيو	VERB	_	_	1	advcl	_	_
 13	آهي	آهي	AUX	_	_	12	aux	_	SpaceAfter=No
 14	،	،	PUNCT	_	_	12	punct	_	_
 
@@ -16666,7 +16666,7 @@
 9	۾	۾	ADP	_	_	8	mark	_	_
 10	قمبر	قمبر	PROPN	_	_	12	obl	_	_
 11	۾	۾	ADP	_	_	10	case	_	_
-12	رهندو	ره	VERB	_	_	4	obj	_	_
+12	رهندو	ره	VERB	_	_	4	advcl	_	_
 13	هئس	هئو	AUX	_	_	12	aux	_	SpaceAfter=No
 14	،	،	PUNCT	_	_	12	punct	_	_
 15	هاڻي	هاڻ	ADV	_	_	23	advmod	_	_
@@ -16824,7 +16824,7 @@
 12	تي	تي	ADP	_	_	11	case	_	_
 13	ساڻس	_	ADV	_	_	15	advmod	_	_
 14	تڪرار	تڪرار	NOUN	_	_	15	xcomp	_	_
-15	هلندڙ	هل	VERB	_	_	4	obj	_	_
+15	هلندڙ	هل	VERB	_	_	4	advcl	_	_
 16	هو	هو	AUX	_	_	15	aux	_	SpaceAfter=No
 17	،	،	PUNCT	_	_	15	punct	_	_
 
@@ -17053,7 +17053,7 @@
 17	جي	جي	ADP	_	_	18	nmod	_	_
 18	ڌر	ڌر	NOUN	_	_	20	obj	_	_
 19	نه	نه	PART	_	_	20	dep	_	_
-20	ڪيو	ڪيو	VERB	_	_	10	obj	_	_
+20	ڪيو	ڪيو	VERB	_	_	10	advcl	_	_
 21	آهي	آهي	AUX	_	_	20	aux	_	SpaceAfter=No
 22	،	،	PUNCT	_	_	20	punct	_	_
 
@@ -17109,7 +17109,7 @@
 17	هاري	هاري	NOUN	_	_	20	obj	_	_
 18	کي	کي	ADP	_	_	17	case	_	_
 19	قتل	قتل	NOUN	_	_	20	compound	_	_
-20	ڪيو	ڪيو	VERB	_	_	10	obj	_	_
+20	ڪيو	ڪيو	VERB	_	_	10	advcl	_	_
 21	آهي	آهي	AUX	_	_	20	aux	_	SpaceAfter=No
 22	،	،	PUNCT	_	_	20	punct	_	_
 
@@ -17898,7 +17898,7 @@
 30	ليبارٽري	_	NOUN	_	_	33	obl	_	_
 31	ڏانهن	ڏانهن	ADV	_	_	30	case	_	_
 32	جزا	_	NOUN	_	_	33	obj	_	_
-33	اماڻيا	_	VERB	_	_	9	obj	_	_
+33	اماڻيا	_	VERB	_	_	9	advcl	_	_
 34	آهن	آهي	AUX	_	_	33	aux	_	SpaceAfter=No
 35	،	،	PUNCT	_	_	33	punct	_	_
 
@@ -18145,7 +18145,7 @@
 20	بخش	بخش	NOUN	_	_	23	obj	_	_
 21	کي	کي	ADP	_	_	20	case	_	_
 22	قتل	قتل	NOUN	_	_	23	compound	_	_
-23	ڪيو	ڪيو	VERB	_	_	13	obj	_	_
+23	ڪيو	ڪيو	VERB	_	_	13	advcl	_	_
 24	آهي	آهي	AUX	_	_	23	aux	_	SpaceAfter=No
 25	،	،	PUNCT	_	_	23	punct	_	_
 
@@ -18519,7 +18519,7 @@
 46	ڪاررواين	ڪارروائي	NOUN	_	_	48	nmod	_	_
 47	جو	جو	ADP	_	_	46	case	_	_
 48	نشانو	نشانو	NOUN	_	_	49	xcomp	_	_
-49	بڻائي	بڻاءِ	VERB	_	_	32	obj	_	_
+49	بڻائي	بڻاءِ	VERB	_	_	32	advcl	_	_
 50	رهي	ره	VERB	_	_	49	compound	_	_
 51	آهي	آهي	AUX	_	_	49	aux	_	SpaceAfter=No
 52	.	.	PUNCT	_	_	49	punct	_	_
@@ -20423,7 +20423,7 @@
 16	مون	مون	PRON	_	_	19	obl	_	_
 17	کان	کان	ADP	_	_	16	case	_	_
 18	واپس	واپس	VERB	_	_	19	compound	_	_
-19	ورتا	ورتو	VERB	_	_	9	obj	_	_
+19	ورتا	ورتو	VERB	_	_	9	advcl	_	_
 20	وڃن	وڃ	VERB	_	_	19	compound	_	SpaceAfter=No
 21	،	،	PUNCT	_	_	19	punct	_	_
 
@@ -20763,7 +20763,7 @@
 33	تباهي	_	ADJ	_	_	34	amod	_	_
 34	ڪناري	ڪنارو	NOUN	_	_	36	obl	_	_
 35	تي	تي	ADP	_	_	34	case	_	_
-36	پهتل	_	VERB	_	_	14	obj	_	_
+36	پهتل	_	VERB	_	_	14	advcl	_	_
 37	آهي	آهي	AUX	_	_	36	aux	_	SpaceAfter=No
 38	،	،	PUNCT	_	_	36	punct	_	_
 
@@ -22091,7 +22091,7 @@
 13	پاڻي	پاڻي	NOUN	_	_	14	obj	_	_
 14	وارڻ	_	VERB	_	_	16	advcl	_	_
 15	لاءِ	لاءِ	ADP	_	_	16	mark	_	_
-16	چيو	چئو	VERB	_	_	6	obj	_	_
+16	چيو	چئو	VERB	_	_	6	advcl	_	_
 17	جنهن	جنهن	PRON	_	_	20	obl	_	_
 18	تان	تان	ADP	_	_	20	mark	_	_
 19	انڪار	انڪار	NOUN	_	_	20	obl	_	_
@@ -23017,7 +23017,7 @@
 20	آبادگارن	آبادگار	NOUN	_	_	18	conj	_	_
 21	کي	کي	ADP	_	_	18	case	_	_
 22	فائدو	فائدو	NOUN	_	_	23	xcomp	_	_
-23	ملي	مل	VERB	_	_	2	obj	_	_
+23	ملي	مل	VERB	_	_	2	advcl	_	_
 24	سگھي	سگھي	AUX	_	_	23	aux	_	SpaceAfter=No
 25	،	،	PUNCT	_	_	23	punct	_	_
 

--- a/not-to-release/dependencies/sd_batch_5_600.conllu
+++ b/not-to-release/dependencies/sd_batch_5_600.conllu
@@ -131,7 +131,7 @@
 28	الڳ	الڳ	ADJ	_	_	29	amod	_	_
 29	بجيٽ	بجيٽ	NOUN	_	_	31	obj	_	_
 30	نه	نه	PART	_	_	31	dep	_	_
-31	رکڻي	_	VERB	_	_	20	obj	_	_
+31	رکڻي	_	VERB	_	_	20	advcl	_	_
 32	پوي	پو	VERB	_	_	31	compound	_	SpaceAfter=No
 33	!!	_	PUNCT	_	_	31	punct	_	_
 34	پر	پر	SCONJ	_	_	31	mark	_	_
@@ -147,7 +147,7 @@
 44	صورتحال	صورتحال	NOUN	_	_	47	obl	_	_
 45	۾	۾	ADP	_	_	44	case	_	_
 46	نه	نه	PART	_	_	47	dep	_	_
-47	وينداسين	ويندو	VERB	_	_	37	obj	_	_
+47	وينداسين	ويندو	VERB	_	_	37	advcl	_	_
 48	جو	جو	ADP	_	_	47	mark	_	_
 49	اسان	اسين	PRON	_	_	55	nsubj	_	_
 50	کي	کي	ADP	_	_	49	case	_	_
@@ -440,7 +440,7 @@
 12	ڌارين	ڌاريون	NOUN	_	_	15	obj	_	_
 13	کي	کي	ADP	_	_	12	case	_	_
 14	نيڪالي	نيڪالي	NOUN	_	_	15	compound	_	_
-15	ڏني	ڏني	VERB	_	_	2	obj	_	_
+15	ڏني	ڏني	VERB	_	_	2	advcl	_	_
 16	وڃي	وڃ	VERB	_	_	15	compound	_	SpaceAfter=No
 17	،	،	PUNCT	_	_	15	punct	_	_
 
@@ -853,7 +853,7 @@
 20	ميسيج	_	NOUN	_	_	21	compound	_	_
 21	ڪري	ڪر	VERB	_	_	23	advcl	_	_
 22	ڌمڪيون	ڌمڪي	NOUN	_	_	23	obj	_	_
-23	ڏئي	ڏئي	VERB	_	_	9	obj	_	_
+23	ڏئي	ڏئي	VERB	_	_	9	advcl	_	_
 24	ٿو	آهي	AUX	_	_	23	aux	_	_
 25	۽	۽	CCONJ	_	_	31	cc	_	_
 26	گهر	گهر	NOUN	_	_	31	obl	_	_
@@ -1202,7 +1202,7 @@
 31	اقليت	_	NOUN	_	_	34	obl	_	_
 32	۾	۾	ADP	_	_	31	case	_	_
 33	تبديل	تبديل	NOUN	_	_	34	xcomp	_	_
-34	ڪري	ڪر	VERB	_	_	16	obj	_	_
+34	ڪري	ڪر	VERB	_	_	16	advcl	_	_
 35	رهي	ره	VERB	_	_	34	compound	_	_
 36	آهي	آهي	AUX	_	_	34	aux	_	_
 37	ڇو	ڇو	ADV	_	_	42	mark	_	_
@@ -1748,7 +1748,7 @@
 58	ان	ان	DET	_	_	59	det	_	_
 59	نتيجي	نتيجو	NOUN	_	_	61	obl	_	_
 60	تي	تي	ADP	_	_	59	case	_	_
-61	پهتي	پهتو	VERB	_	_	34	obj	_	_
+61	پهتي	پهتو	VERB	_	_	34	advcl	_	_
 62	آهيان	آهي	AUX	_	_	61	aux	_	_
 63	ته	ته	SCONJ	_	_	73	mark	_	_
 64	پاڪ	_	NOUN	_	_	65	compound	_	_
@@ -1907,7 +1907,7 @@
 31	جي	جي	ADP	_	_	30	case	_	_
 32	ڏي	ڏي	VERB	_	_	34	compound	_	_
 33	وٺ	وٺ	VERB	_	_	34	compound	_	_
-34	ڪرڻ	ڪر	VERB	_	_	2	obj	_	_
+34	ڪرڻ	ڪر	VERB	_	_	2	advcl	_	_
 35	هو	هو	AUX	_	_	34	aux	_	SpaceAfter=No
 36	،	،	PUNCT	_	_	34	punct	_	_
 
@@ -2068,7 +2068,7 @@
 25	تي	تي	ADP	_	_	24	case	_	_
 26	جلد	جلد	NOUN	_	_	28	obl	_	_
 27	عمل	عمل	NOUN	_	_	28	compound	_	_
-28	ڪيو	ڪيو	VERB	_	_	18	obj	_	_
+28	ڪيو	ڪيو	VERB	_	_	18	advcl	_	_
 29	ويندو	ويندو	VERB	_	_	28	compound	_	SpaceAfter=No
 30	،	،	PUNCT	_	_	28	punct	_	_
 
@@ -4170,7 +4170,7 @@
 20	سان	سان	ADP	_	_	19	case	_	_
 21	جنسي	_	ADJ	_	_	22	amod	_	_
 22	ڏاڍائي	ڏاڍ	NOUN	_	_	23	compound	_	_
-23	ڪندا	ڪن	VERB	_	_	6	obj	_	_
+23	ڪندا	ڪن	VERB	_	_	6	advcl	_	_
 24	رهيا	ره	VERB	_	_	23	compound	_	_
 25	آهن	آهي	AUX	_	_	23	aux	_	SpaceAfter=No
 26	،	،	PUNCT	_	_	23	punct	_	_
@@ -4579,7 +4579,7 @@
 21	مقبوليت	مقبوليت	NOUN	_	_	23	nmod	_	_
 22	جو	جو	ADP	_	_	21	case	_	_
 23	گراف	گراف	NOUN	_	_	24	obj	_	_
-24	ڪيرائي	_	VERB	_	_	6	obj	_	_
+24	ڪيرائي	_	VERB	_	_	6	advcl	_	_
 25	رهي	ره	VERB	_	_	24	compound	_	_
 26	آهي	آهي	AUX	_	_	24	aux	_	SpaceAfter=No
 27	،	،	PUNCT	_	_	24	punct	_	_
@@ -6424,7 +6424,7 @@
 6	لوڙهي	_	NOUN	_	_	9	nsubj	_	_
 7	اجهو	اجهو	ADV	_	_	9	advmod	_	_
 8	چريو	_	NOUN	_	_	9	xcomp	_	_
-9	ٿيڻ	ٿي	VERB	_	_	2	obj	_	_
+9	ٿيڻ	ٿي	VERB	_	_	2	advcl	_	_
 10	وارو	وارو	ADP	_	_	9	mark	_	_
 11	آهي	آهي	AUX	_	_	9	aux	_	SpaceAfter=No
 12	.	.	PUNCT	_	_	9	punct	_	_
@@ -8490,7 +8490,7 @@
 14	شگر	شگر	NOUN	_	_	15	nmod	_	_
 15	ملن	مل	NOUN	_	_	17	nsubj	_	_
 16	چمنيون	_	NOUN	_	_	17	obj	_	_
-17	ٻاريون	_	VERB	_	_	8	obj	_	_
+17	ٻاريون	_	VERB	_	_	8	advcl	_	_
 18	آهن	آهي	AUX	_	_	17	aux	_	_
 19	۽	۽	CCONJ	_	_	29	cc	_	_
 20	ڪيترين	ڪيترو	ADJ	_	_	22	amod	_	_
@@ -8774,7 +8774,7 @@
 25	ڪري	ڪر	VERB	_	_	28	advcl	_	_
 26	اهو	اهو	DET	_	_	27	det	_	_
 27	سوڪ	_	NOUN	_	_	28	obj	_	_
-28	کائيندو	_	VERB	_	_	15	obj	_	_
+28	کائيندو	_	VERB	_	_	15	advcl	_	_
 29	۽	۽	CCONJ	_	_	33	cc	_	_
 30	وزن	وزن	NOUN	_	_	33	obl	_	_
 31	۾	۾	ADP	_	_	30	case	_	_
@@ -9245,7 +9245,7 @@
 17	(	(	PUNCT	_	_	18	punct	_	SpaceAfter=No
 18	وظيفو	_	NOUN	_	_	16	conj	_	SpaceAfter=No
 19	)	)	PUNCT	_	_	18	punct	_	_
-20	ڏنو	ڏنو	VERB	_	_	3	obj	_	_
+20	ڏنو	ڏنو	VERB	_	_	3	advcl	_	_
 21	ويندو	ويندو	VERB	_	_	20	compound	_	SpaceAfter=No
 22	.	.	PUNCT	_	_	20	punct	_	_
 
@@ -9632,7 +9632,7 @@
 10	سڪرنڊ	_	PROPN	_	_	8	conj	_	_
 11	جي	جي	ADP	_	_	8	case	_	_
 12	سامهون	سامهون	NOUN	_	_	13	obl	_	_
-13	ٺاهي	ٺاه	VERB	_	_	3	obj	_	_
+13	ٺاهي	ٺاه	VERB	_	_	3	advcl	_	_
 14	وڃي	وڃ	VERB	_	_	13	compound	_	SpaceAfter=No
 15	،	،	PUNCT	_	_	13	punct	_	_
 
@@ -9651,7 +9651,7 @@
 11	احمد	احمد	PROPN	_	_	8	conj	_	_
 12	جي	جي	ADP	_	_	8	case	_	_
 13	سامهون	سامهون	NOUN	_	_	14	obl	_	_
-14	ٺاهي	ٺاه	VERB	_	_	3	obj	_	_
+14	ٺاهي	ٺاه	VERB	_	_	3	advcl	_	_
 15	وڃي	وڃ	VERB	_	_	14	compound	_	SpaceAfter=No
 16	.	.	PUNCT	_	_	14	punct	_	_
 
@@ -9693,7 +9693,7 @@
 7	تي	تي	ADP	_	_	6	case	_	_
 8	بحث	بحث	NOUN	_	_	9	compound	_	_
 9	ڪرڻ	ڪر	VERB	_	_	10	xcomp	_	_
-10	اجايو	_	VERB	_	_	2	obj	_	_
+10	اجايو	_	VERB	_	_	2	advcl	_	_
 11	آهي	آهي	AUX	_	_	10	aux	_	SpaceAfter=No
 12	،	،	PUNCT	_	_	10	punct	_	_
 
@@ -10894,7 +10894,7 @@
 11	طبلي	طبلي	NOUN	_	_	14	obl	_	_
 12	تي	تي	ADP	_	_	11	case	_	_
 13	عبور	_	NOUN	_	_	14	compound	_	_
-14	هوندو	هوندو	VERB	_	_	5	obj	_	_
+14	هوندو	هوندو	VERB	_	_	5	advcl	_	_
 15	آهي	آهي	AUX	_	_	14	aux	_	SpaceAfter=No
 16	،	،	PUNCT	_	_	14	punct	_	_
 
@@ -11255,7 +11255,7 @@
 29	خلاف	خلاف	ADP	_	_	26	mark	_	_
 30	قانوني	_	NOUN	_	_	31	nmod	_	_
 31	ڪارروائي	ڪارروائي	NOUN	_	_	32	compound	_	_
-32	ڪئي	ڪئي	VERB	_	_	16	obj	_	_
+32	ڪئي	ڪئي	VERB	_	_	16	advcl	_	_
 33	وڃي	وڃ	VERB	_	_	32	compound	_	SpaceAfter=No
 34	،	،	PUNCT	_	_	32	punct	_	_
 
@@ -12508,7 +12508,7 @@
 36	مارئي	مارئي	PROPN	_	_	38	nmod	_	_
 37	جو	جو	ADP	_	_	36	case	_	_
 38	ميلو	ميلو	NOUN	_	_	39	obj	_	_
-39	ملهايو	ملها	VERB	_	_	9	obj	_	_
+39	ملهايو	ملها	VERB	_	_	9	advcl	_	_
 40	وڃي	وڃ	VERB	_	_	39	compound	_	SpaceAfter=No
 41	.	.	PUNCT	_	_	39	punct	_	_
 
@@ -12792,7 +12792,7 @@
 25	پاڻي	پاڻي	NOUN	_	_	26	obj	_	_
 26	ڀريندي	ڀر	VERB	_	_	28	advcl	_	_
 27	زوري	_	VERB	_	_	28	xcomp	_	_
-28	کڻي	کڻي	VERB	_	_	1	obj	_	_
+28	کڻي	کڻي	VERB	_	_	1	advcl	_	_
 29	ويو	ويو	VERB	_	_	28	compound	_	_
 30	هو	هو	AUX	_	_	28	aux	_	SpaceAfter=No
 31	.	.	PUNCT	_	_	28	punct	_	_
@@ -13116,7 +13116,7 @@
 21	وارث	_	NOUN	_	_	24	nsubj	_	_
 22	سخت	سخت	ADJ	_	_	23	amod	_	_
 23	پريشان	_	NOUN	_	_	24	xcomp	_	_
-24	هوندا	هوندو	VERB	_	_	10	obj	_	_
+24	هوندا	هوندو	VERB	_	_	10	advcl	_	_
 25	آهن	آهي	AUX	_	_	24	aux	_	SpaceAfter=No
 26	،	،	PUNCT	_	_	24	punct	_	_
 
@@ -13433,7 +13433,7 @@
 15	جاني	_	NOUN	_	_	16	nmod	_	_
 16	نقصان	نقصان	NOUN	_	_	18	obj	_	_
 17	نه	نه	PART	_	_	18	dep	_	_
-18	ٿيو	ٿي	VERB	_	_	8	obj	_	_
+18	ٿيو	ٿي	VERB	_	_	8	advcl	_	_
 19	آهي	آهي	AUX	_	_	18	aux	_	SpaceAfter=No
 20	.	.	PUNCT	_	_	18	punct	_	_
 
@@ -13453,7 +13453,7 @@
 12	عملي	عملي	NOUN	_	_	14	nmod	_	_
 13	جي	جي	ADP	_	_	12	case	_	_
 14	فهرست	_	NOUN	_	_	15	obj	_	_
-15	ملي	مل	VERB	_	_	4	obj	_	_
+15	ملي	مل	VERB	_	_	4	advcl	_	_
 16	وئي	وئي	VERB	_	_	15	compound	_	_
 17	آهي	آهي	AUX	_	_	15	aux	_	SpaceAfter=No
 18	،	،	PUNCT	_	_	15	punct	_	_
@@ -13514,7 +13514,7 @@
 30	ھاڻي	ھاڻ	ADV	_	_	33	advmod	_	_
 31	مختلف	مختلف	ADJ	_	_	32	amod	_	_
 32	زندگي	زندگي	NOUN	_	_	33	obj	_	_
-33	گذاري	گذار	VERB	_	_	26	obj	_	_
+33	گذاري	گذار	VERB	_	_	26	advcl	_	_
 34	رھيو	_	VERB	_	_	33	compound	_	_
 35	آھيان	آهي	AUX	_	_	33	aux	_	SpaceAfter=No
 36	،	،	PUNCT	_	_	33	punct	_	_
@@ -13589,14 +13589,14 @@
 15	تو	تو	PRON	_	_	18	iobj	_	_
 16	کي	کي	ADP	_	_	15	case	_	_
 17	ڪنھن	_	PRON	_	_	18	nsubj	_	_
-18	ٻڌايو	ٻڌاءِ	VERB	_	_	2	obj	_	_
+18	ٻڌايو	ٻڌاءِ	VERB	_	_	2	advcl	_	_
 19	آھي	آهي	AUX	_	_	18	aux	_	_
 20	ته	ته	SCONJ	_	_	25	mark	_	_
 21	تون	تون	PRON	_	_	25	nsubj	_	_
 22	جارج	_	PROPN	_	_	23	compound	_	_
 23	بش	بش	PROPN	_	_	25	obl	_	_
 24	جھڙو	_	PRON	_	_	25	obl	_	_
-25	لڳين	لڳ	VERB	_	_	18	obj	_	_
+25	لڳين	لڳ	VERB	_	_	18	advcl	_	_
 26	ٿو	آهي	AUX	_	_	25	aux	_	SpaceAfter=No
 27	،	،	PUNCT	_	_	25	punct	_	_
 

--- a/not-to-release/dependencies/sd_long_sentences_retokenized.conllu
+++ b/not-to-release/dependencies/sd_long_sentences_retokenized.conllu
@@ -456,7 +456,7 @@
 27	مارڪيٽ	مارڪيٽ	NOUN	_	_	30	obl	_	_
 28	۾	۾	ADP	_	_	27	case	_	_
 29	باهه	باهه	NOUN	_	_	30	compound	_	_
-30	ڏني	ڏني	VERB	_	_	6	obj	_	_
+30	ڏني	ڏني	VERB	_	_	6	advcl	_	_
 31	وڃي	وڃ	VERB	_	_	30	compound	_	_
 32	ٿي	آهي	AUX	_	_	30	aux	_	SpaceAfter=No
 33	۔	_	PUNCT	_	_	30	punct	_	_

--- a/not-to-release/dependencies/sd_nopos_1000.conllu
+++ b/not-to-release/dependencies/sd_nopos_1000.conllu
@@ -1015,7 +1015,7 @@
 20	جيڪي	جيڪو	DET	_	_	22	det	_	_
 21	خاص	خاص	ADJ	_	_	22	amod	_	_
 22	پڪوان	_	NOUN	_	_	23	obj	_	_
-23	ٺاهيندو	_	VERB	_	_	7	obj	_	_
+23	ٺاهيندو	_	VERB	_	_	7	advcl	_	_
 24	آهي	آهي	AUX	_	_	23	aux	_	SpaceAfter=No
 25	،	،	PUNCT	_	_	23	punct	_	_
 
@@ -3574,7 +3574,7 @@
 7	ته	ته	SCONJ	_	_	10	mark	_	_
 8	هو	هو	DET	_	_	10	nsubj	_	_
 9	ڪٿي	ڪٿي	ADV	_	_	10	advmod	_	_
-10	ويٺو	ويٺو	VERB	_	_	5	obj	_	_
+10	ويٺو	ويٺو	VERB	_	_	5	advcl	_	_
 11	آهي	آهي	AUX	_	_	10	aux	_	SpaceAfter=No
 12	.	.	PUNCT	_	_	10	punct	_	_
 
@@ -5465,7 +5465,7 @@
 13	اهي	اهي	DET	_	_	14	det	_	_
 14	شـڪـلـيـون	_	NOUN	_	_	16	nsubj	_	_
 15	ڪـنـهـن	_	PRON	_	_	16	nsubj	_	_
-16	ٺـاهـيـون	_	VERB	_	_	10	obj	_	_
+16	ٺـاهـيـون	_	VERB	_	_	10	advcl	_	_
 17	آهن	آهي	AUX	_	_	16	aux	_	SpaceAfter=No
 18	.	.	PUNCT	_	_	16	punct	_	_
 

--- a/not-to-release/dependencies/sd_punct_batch.conllu
+++ b/not-to-release/dependencies/sd_punct_batch.conllu
@@ -477,7 +477,7 @@
 32	وقت	وقت	NOUN	_	_	35	nsubj	_	_
 33	تمام	تمام	ADV	_	_	34	advmod	_	_
 34	سڀاڳو	_	ADJ	_	_	35	xcomp	_	_
-35	هوندو	هوندو	VERB	_	_	25	obj	_	_
+35	هوندو	هوندو	VERB	_	_	25	advcl	_	_
 36	آهي	آهي	AUX	_	_	35	aux	_	SpaceAfter=No
 37	.	.	PUNCT	_	_	35	punct	_	_
 
@@ -1485,7 +1485,7 @@
 14	اٿئي	آهي	VERB	_	_	13	compound	_	_
 15	ته	ته	SCONJ	_	_	17	mark	_	_
 16	آءٌ	آءٌ	PRON	_	_	17	nsubj	_	_
-17	هارائي	_	VERB	_	_	13	obj	_	_
+17	هارائي	_	VERB	_	_	13	advcl	_	_
 18	ويٺو	ويٺو	VERB	_	_	17	compound	_	_
 19	آهيان	آهي	AUX	_	_	17	aux	_	SpaceAfter=No
 20	.	.	PUNCT	_	_	17	punct	_	_
@@ -2266,7 +2266,7 @@
 14	خذمت	_	NOUN	_	_	17	obl	_	_
 15	۾	۾	ADP	_	_	14	case	_	_
 16	پيش	پيش	VERB	_	_	17	xcomp	_	_
-17	ڪري	ڪر	VERB	_	_	2	obj	_	_
+17	ڪري	ڪر	VERB	_	_	2	advcl	_	_
 18	سگهان	سگهي	AUX	_	_	17	aux	_	_
 19	ته	ته	SCONJ	_	_	23	mark	_	_
 20	ڪهڙو	ڪهڙو	PRON	_	_	23	obl	_	_
@@ -2545,7 +2545,7 @@
 40	توسان	توسان	PRON	_	_	43	nsubj	_	_
 41	ڇا	ڇا	PRON	_	_	43	obj	_	_
 42	ٿو	آهي	AUX	_	_	43	aux	_	_
-43	وهي	وه	VERB	_	_	36	obj	_	_
+43	وهي	وه	VERB	_	_	36	advcl	_	_
 44	واپري	_	VERB	_	_	36	obj	_	SpaceAfter=No
 45	.	.	PUNCT	_	_	43	punct	_	_
 

--- a/not-to-release/dependencies/sd_small_update.conllu
+++ b/not-to-release/dependencies/sd_small_update.conllu
@@ -508,7 +508,7 @@
 26	نه	نه	PART	_	_	29	mark	_	_
 27	ته	ته	SCONJ	_	_	29	mark	_	_
 28	توکي	تو	PRON	_	_	29	obj	_	_
-29	ماري	مار	VERB	_	_	16	obj	_	_
+29	ماري	مار	VERB	_	_	16	advcl	_	_
 30	ڇڏيندس	_	NOUN	_	_	29	aux	_	_
 31	،	،	PUNCT	_	_	29	punct	_	_
 
@@ -554,7 +554,7 @@
 21	ڏسجي	ڏسج	VERB	_	_	12	obj	_	_
 22	؟	؟	PUNCT	_	_	21	punct	_	_
 23	ڪڙميءَ	ڪڙمي	NOUN	_	_	24	nsubj	_	_
-24	چيو	چئو	VERB	_	_	12	obj	_	_
+24	چيو	چئو	VERB	_	_	12	advcl	_	_
 25	ته	ته	SCONJ	_	_	24	mark	_	_
 26	:	:	PUNCT	_	_	24	punct	_	_
 27	سائين	سائين	NOUN	_	_	33	obl	_	_

--- a/not-to-release/xpos_features/sd_780_part_A.conllu
+++ b/not-to-release/xpos_features/sd_780_part_A.conllu
@@ -169,7 +169,7 @@
 25	ته	ته	SCONJ	CS	_	28	mark	_	_
 26	گيج	گيج	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	28	obl	_	_
 27	نه	نه	PART	PART	_	28	advmod	_	_
-28	لڙهيا	لڙه	VERB	VM	Aspect=Perf|Number=Plur	10	obj	_	_
+28	لڙهيا	لڙه	VERB	VM	Aspect=Perf|Number=Plur	10	advcl	_	_
 29	هئا	هئو	AUX	VAUX	Number=Plur|Tense=Past	28	aux	_	_
 30	۽	۽	CCONJ	CC	_	36	cc	_	_
 31	نه	نه	PART	PART	_	36	dep	_	_
@@ -2364,7 +2364,7 @@
 15	ته	ته	SCONJ	CS	_	18	mark	_	_
 16	ڇا	ڇا	PRON	PRWH	Case=Acc|Gender=Masc|Number=Sing	18	obl	_	_
 17	پارليامينٽ	پارليامينٽ	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	18	nsubj	_	_
-18	چاهي	چاه	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	13	obj	_	_
+18	چاهي	چاه	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	13	advcl	_	_
 19	ٿي	آهي	AUX	VAUX	Gender=Fem|Number=Sing|Person=3|Tense=Pres	18	aux	_	_
 20	ته	ته	SCONJ	CS	_	30	mark	_	_
 21	سندن	سندو	PRON	PRP	Case=Acc|Gender=Fem|Number=Plur|Person=3	22	obl	_	_
@@ -4966,7 +4966,7 @@
 16	ڇڏي	ڇڏ	VERB	VM	Aspect=Perf|VerbForm=Conv|Voice=Act	19	advcl	_	_
 17	پرڏيهه	پرڏيهه	NOUN	NN	Case=Nom|Number=Sing	18	nmod	_	_
 18	دورا	دورو	NOUN	NN	Case=Nom|Number=Plur	19	obj	_	_
-19	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	2	obj	_	_
+19	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	2	advcl	_	_
 20	رهيو	رهيو	VERB	VM	Aspect=Perf|Number=Sing|Person=3	19	compound	_	_
 21	آهي	آهي	AUX	VAUX	Person=3|Tense=Pres	19	aux	_	_
 22	،	،	PUNCT	PUNCT	_	19	punct	_	_
@@ -6495,7 +6495,7 @@
 17	بس	بس	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	advmod	_	_
 18	اجهو	اجهو	ADV	ADT	_	20	advmod	_	_
 19	ٿو	آهي	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Pres	20	aux	_	_
-20	پورو	پورو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	14	obj	_	_
+20	پورو	پورو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	14	advcl	_	_
 21	ڪريانس	ڪري	VERB	VMX	Aspect=Imp|Person=1|Voice=Act	14	obj	_	_
 22	،	،	PUNCT	PUNCT	_	10	punct	_	_
 

--- a/not-to-release/xpos_features/sd_780_part_B.conllu
+++ b/not-to-release/xpos_features/sd_780_part_B.conllu
@@ -3909,7 +3909,7 @@
 12	انهيءَ	ان	DET	PRD	Case=Acc|Number=Sing	13	det	_	_
 13	گدڙ	گدڙ	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	15	obj	_	_
 14	کي	کي	ADP	PSP	_	13	case	_	_
-15	ڏسان	ڏس	VERB	VM	Aspect=Imp|Number=Sing|Person=1	7	obj	_	_
+15	ڏسان	ڏس	VERB	VM	Aspect=Imp|Number=Sing|Person=1	7	advcl	_	_
 16	آءٌ	آءٌ	PRON	PRP	Case=Nom|Number=Sing|Person=1	17	nsubj	_	_
 17	چوانس	چو	VERB	VMX	Aspect=Imp|Number=Sing|Number[obj]=Sing|Number[subj]=Sing|Person=1|Person[obj]=1|Person[subj]=1	7	obj	_	_
 18	ٿو	آهي	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Pres	17	aux	_	_

--- a/not-to-release/xpos_features/sd_batch_2_p1_labeled_2025-04-29.txt
+++ b/not-to-release/xpos_features/sd_batch_2_p1_labeled_2025-04-29.txt
@@ -123,7 +123,7 @@
 12	راجا	راجا	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nmod	_	_
 13	سوتون	سوت	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	_
 14	ڪيانگان	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	obl	_	_
-15	پهچي	پهچ	VERB	VM	Aspect=Imp	9	obj	_	_
+15	پهچي	پهچ	VERB	VM	Aspect=Imp	9	advcl	_	_
 16	ويو	ويو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	15	compound	_	_
 17	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	15	aux	_	SpaceAfter=No
 18	.	.	PUNCT	PUNCT	_	15	punct	_	_
@@ -1619,7 +1619,7 @@
 11	مون	مون	PRON	PRP	Case=Acc|Number=Sing|Person=1	14	obj	_	_
 12	کي	کي	ADP	PSP	_	11	case	_	_
 13	ڪائوتان	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	xcomp	_	_
-14	سمجهيو	سمجهيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	4	obj	_	_
+14	سمجهيو	سمجهيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	4	advcl	_	_
 15	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	14	aux	_	SpaceAfter=No
 16	،	،	PUNCT	PUNCT	_	14	punct	_	_
 
@@ -2813,7 +2813,7 @@
 7	گڏجي	گڏ	ADV	ADV	_	10	advmod	_	_
 8	سفر	سفر	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	compound	_	_
 9	نٿا	آهي	AUX	VAUX	Gender=Masc|Number=Plur|Tense=Pres	10	aux	_	_
-10	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	2	obj	_	_
+10	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	2	advcl	_	_
 11	سگهون	_	AUX	VAUX	Gender=Masc|Number=Plur|Tense=Pres	10	aux	_	SpaceAfter=No
 12	.	.	PUNCT	PUNCT	_	10	punct	_	_
 
@@ -3545,7 +3545,7 @@
 6	تون	تون	PRON	PRP	Case=Nom|Number=Sing|Person=2	9	nsubj	_	_
 7	ڪِن	ڪو	PRON	PRP	Case=Acc|Number=Plur|Person=1	8	nmod	_	_
 8	ڪچرو	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	xcomp	_	_
-9	کائيندو	_	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart	3	obj	_	_
+9	کائيندو	_	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart	3	advcl	_	_
 10	رهندو	ره	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart	9	compound	_	_
 11	آهين	آهي	AUX	VAUX	Number=Sing|Person=1|Tense=Pres	9	aux	_	SpaceAfter=No
 12	.	.	PUNCT	PUNCT	_	9	punct	_	_
@@ -3679,7 +3679,7 @@
 16	تي	تي	ADP	PSPL	_	17	mark	_	_
 17	رک	_	VERB	VM	Aspect=Imp|Number=Sing|Person=3	9	obj	_	_
 18	ته	ته	SCONJ	CS	_	19	mark	_	_
-19	کڻي	کڻي	VERB	VM	Aspect=Perf|VerbForm=Conv	9	obj	_	_
+19	کڻي	کڻي	VERB	VM	Aspect=Perf|VerbForm=Conv	9	advcl	_	_
 20	وڃان	وڃ	VERB	VM	Aspect=Imp|Number=Sing|Person=1	19	compound	_	SpaceAfter=No
 21	.	.	PUNCT	PUNCT	_	19	punct	_	_
 
@@ -4592,7 +4592,7 @@
 10	گدڙ	گدڙ	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	13	obj	_	_
 11	کي	کي	ADP	PSP	_	10	case	_	_
 12	به	به	PART	PART	_	13	mark	_	_
-13	کڻندو	_	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	2	obj	_	_
+13	کڻندو	_	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	2	advcl	_	_
 14	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	13	aux	_	SpaceAfter=No
 15	،	،	PUNCT	PUNCT	_	13	punct	_	_
 
@@ -5096,7 +5096,7 @@
 24	پڇ	پڇ	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	26	obl	_	_
 25	سان	سان	ADP	PSP	_	26	mark	_	_
 26	ڇڪي	ڇڪ	VERB	VM	Aspect=Perf|VerbForm=Conv	27	xcomp	_	_
-27	ٻڌل	ٻڌ	VERB	VM	Aspect=Perf|Number=Sing	17	obj	_	_
+27	ٻڌل	ٻڌ	VERB	VM	Aspect=Perf|Number=Sing	17	advcl	_	_
 28	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	27	aux	_	SpaceAfter=No
 29	.	.	PUNCT	PUNCT	_	27	punct	_	_
 
@@ -5697,7 +5697,7 @@
 5	پرانهين	_	ADJ	JJ	Case=Nom|Degree=Pos|Gender=Masc|Number=Sing	6	nmod	_	_
 6	ملڪ	ملڪ	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	8	obl	_	_
 7	مان	مان	ADP	PSPL	_	8	mark	_	_
-8	آيو	آءَ	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	1	obj	_	_
+8	آيو	آءَ	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	1	advcl	_	_
 9	آهين	آهي	AUX	VAUX	Number=Sing|Person=1|Tense=Pres	8	aux	_	SpaceAfter=No
 10	.	.	PUNCT	PUNCT	_	8	punct	_	_
 
@@ -5816,7 +5816,7 @@
 27	ماني	ماني	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	28	nmod	_	_
 28	ڀور	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	30	obj	_	_
 29	ته	ته	PART	PART	_	28	advmod:emph	_	_
-30	ملي	مل	VERB	VM	Aspect=Imp|Voice=Act	4	obj	_	_
+30	ملي	مل	VERB	VM	Aspect=Imp|Voice=Act	4	advcl	_	_
 31	ويندو	ويندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|Person=3	30	compound	_	SpaceAfter=No
 32	،	،	PUNCT	PUNCT	_	30	punct	_	_
 
@@ -8154,7 +8154,7 @@
 16	سان	سان	ADP	PSP	_	15	case	_	_
 17	گڏ	گڏ	ADV	ADV	_	19	advmod	_	_
 18	اتي	اتي	ADV	ADP	_	19	advmod	_	_
-19	رهندو	ره	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart	2	obj	_	_
+19	رهندو	ره	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart	2	advcl	_	_
 20	هو	هو	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Past	19	aux	_	SpaceAfter=No
 21	.	.	PUNCT	PUNCT	_	19	punct	_	_
 
@@ -8396,7 +8396,7 @@
 8	مڪسل	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
 9	اتي	اتي	ADV	ADP	_	10	advmod	_	_
 10	اچي	اچ	VERB	VM	Aspect=Perf|VerbForm=Conv	11	xcomp	_	_
-11	سمهندو	_	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart	1	obj	_	_
+11	سمهندو	_	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart	1	advcl	_	_
 12	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	11	aux	_	SpaceAfter=No
 13	.	.	PUNCT	PUNCT	_	11	punct	_	_
 
@@ -10303,7 +10303,7 @@
 18	اهو	اهو	DET	PRD	Case=Nom|Gender=Masc|Number=Sing	19	det	_	_
 19	بل	بل	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	21	obj	_	_
 20	پيش	پيش	VERB	VM	Aspect=Imp|Voice=Act	21	compound	_	_
-21	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	5	obj	_	_
+21	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	5	advcl	_	_
 22	ويندو	ويندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|Person=3|Voice=Act	21	compound	_	SpaceAfter=No
 23	.	.	PUNCT	PUNCT	_	21	punct	_	_
 
@@ -10758,7 +10758,7 @@
 19	ڳوٺن	ڳوٺ	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	22	obj	_	_
 20	کي	کي	ADP	PSP	_	22	obj	_	_
 21	پڪو	_	ADJ	JJ	Case=Nom|Degree=Pos|Number=Sing	22	compound	_	_
-22	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	14	obj	_	_
+22	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	14	advcl	_	_
 23	ويندو	ويندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|Person=3|VerbForm=PresPart	22	compound	_	SpaceAfter=No
 24	،	،	PUNCT	PUNCT	_	22	punct	_	_
 

--- a/not-to-release/xpos_features/sd_batch_3_labeled_2025-03-31.txt
+++ b/not-to-release/xpos_features/sd_batch_3_labeled_2025-03-31.txt
@@ -310,7 +310,7 @@
 23	سياستدانن	سياست	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	25	nmod	_	_
 24	جو	جو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Sing	23	case	_	_
 25	احتساب	احتساب	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	26	xcomp	_	_
-26	ٿيڻو	ٿي	VERB	VM	Aspect=Imp|Number=Sing|VerbForm=FutPart|Voice=Act	17	obj	_	_
+26	ٿيڻو	ٿي	VERB	VM	Aspect=Imp|Number=Sing|VerbForm=FutPart|Voice=Act	17	advcl	_	_
 27	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	26	aux	_	_
 28	ته	ته	SCONJ	CS	_	36	mark	_	_
 29	پوءِ	پوءِ	ADP	PSP	_	26	mark	_	_
@@ -523,7 +523,7 @@
 17	کانسواءِ	کان	ADP	PSP	_	16	case	_	_
 18	اقتدار	اقتدار	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	20	obl	_	_
 19	۾	۾	ADP	PSPL	_	18	case	_	_
-20	آئي	آئي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing|Person=3	2	obj	_	_
+20	آئي	آئي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing|Person=3	2	advcl	_	_
 21	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	20	aux	_	SpaceAfter=No
 22	،	،	PUNCT	PUNCT	_	20	punct	_	_
 
@@ -1319,7 +1319,7 @@
 35	صحافين	صحافي	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	38	obl	_	_
 36	کان	کان	ADP	PSP	_	35	case	_	_
 37	معافي	_	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	38	compound	_	_
-38	ورتي	ورتي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	16	obj	_	_
+38	ورتي	ورتي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	16	advcl	_	_
 39	وئي	وئي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing|Person=3	38	compound	_	_
 40	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	38	aux	_	_
 41	۽	۽	CCONJ	CC	_	51	cc	_	_
@@ -1484,7 +1484,7 @@
 12	اقتدار	اقتدار	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obl	_	_
 13	۾	۾	ADP	PSPL	_	15	obl	_	_
 14	ناهي	ناهي	AUX	VAUX	Number=Sing|Tense=Pres	15	aux	_	_
-15	آئي	آئي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	4	obj	_	SpaceAfter=No
+15	آئي	آئي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	4	advcl	_	SpaceAfter=No
 16	،	،	PUNCT	PUNCT	_	15	punct	_	_
 17	عوام	عوام	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	25	nsubj	_	_
 18	پيپلز	پيپلز	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	19	compound	_	_
@@ -2031,7 +2031,7 @@
 14	ڌار	_	ADJ	JJ	Case=Nom|Degree=Pos|Gender=Masc	15	compound	_	_
 15	ڌار	_	ADJ	JJ	Case=Nom|Degree=Pos|Gender=Masc|Number=Sing	17	obl	_	_
 16	دبئي	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	obl	_	_
-17	پهتا	پهتو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	6	obj	_	SpaceAfter=No
+17	پهتا	پهتو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	6	advcl	_	SpaceAfter=No
 18	،	،	PUNCT	PUNCT	_	17	punct	_	_
 19	اتان	اتي	ADV	ADP	_	25	advmod	_	_
 20	وري	وري	ADV	ADM	_	25	advmod	_	_
@@ -2564,7 +2564,7 @@
 55	جي	جي	ADP	PSPG	Case=Acc|Gender=Masc|Number=Sing	54	case	_	_
 56	ڏينهن	ڏينهن	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	58	obl	_	_
 57	بند	بند	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	58	xcomp	_	_
-58	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	36	obj	_	_
+58	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	36	advcl	_	_
 59	ويو	ويو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	58	compound	_	_
 60	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	58	aux	_	_
 61	بهرحال	بهرحال	ADV	ADV	_	66	advmod	_	_
@@ -3318,7 +3318,7 @@
 18	ختم	ختم	ADJ	JJ	Case=Nom|Degree=Pos	21	compound	_	_
 19	نه	نه	PART	PART	_	21	dep	_	_
 20	ٿيون	ٿي	VERB	VM	Aspect=Imp|Number=Plur|Voice=Act	21	compound	_	_
-21	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	4	obj	_	_
+21	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	4	advcl	_	_
 22	سگهن	سگهي	AUX	VAUX	Number=Plur|Person=3	21	aux	_	SpaceAfter=No
 23	.	.	PUNCT	PUNCT	_	21	punct	_	_
 
@@ -4812,7 +4812,7 @@
 9	ته	ته	SCONJ	CS	_	12	mark	_	_
 10	گهڻو	گهڻو	ADJ	JJ	Case=Nom|Degree=Pos|Gender=Masc|Number=Sing	11	amod	_	_
 11	ڪجهه	ڪجهه	ADJ	JJ	Case=Nom|Degree=Pos	12	nsubj	_	_
-12	لڪيل	_	VERB	VM	Aspect=Perf|VerbForm=Vnoun	6	obj	_	_
+12	لڪيل	_	VERB	VM	Aspect=Perf|VerbForm=Vnoun	6	advcl	_	_
 13	ڪونهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	12	aux	_	SpaceAfter=No
 14	.	.	PUNCT	PUNCT	_	12	punct	_	_
 
@@ -7373,7 +7373,7 @@
 16	تي	تي	ADP	PSPL	_	15	case	_	_
 17	عراق	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	obl	_	_
 18	ڇو	_	VERB	VM	Aspect=Imp|Voice=Act	19	xcomp	_	_
-19	ويا	ويو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	4	obj	_	_
+19	ويا	ويو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	4	advcl	_	_
 20	هئا	هئو	AUX	VAUX	Number=Plur|Tense=Past	19	aux	_	SpaceAfter=No
 21	.	.	PUNCT	PUNCT	_	19	punct	_	_
 
@@ -7581,7 +7581,7 @@
 10	سان	سان	ADP	PSP	_	9	case	_	_
 11	ٽارگيٽ	ٽارگيٽ	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	13	obj	_	_
 12	حاصل	حاصل	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	compound	_	_
-13	ٿئي	ٿي	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	4	obj	_	_
+13	ٿئي	ٿي	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	4	advcl	_	_
 14	يا	يا	CCONJ	CC	_	16	cc	_	_
 15	نه	نه	PART	PART	_	16	dep	_	_
 16	ٿئي	ٿي	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	13	conj	_	_
@@ -8754,7 +8754,7 @@
 25	به	به	PART	PART	_	24	advmod:emph	_	_
 26	حاوي	_	ADJ	JJ	Case=Nom|Degree=Pos|Number=Sing	28	compound	_	_
 27	نه	نه	PART	PART	_	28	dep	_	_
-28	ٿيندو	آهي	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	18	obj	_	SpaceAfter=No
+28	ٿيندو	آهي	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	18	advcl	_	SpaceAfter=No
 29	.	.	PUNCT	PUNCT	_	28	punct	_	_
 
 # sent_id = 4125
@@ -9552,7 +9552,7 @@
 5	جي	جي	ADP	PSPG	Case=Nom|Gender=Fem|Number=Sing	4	case	_	_
 6	دنيا	دنيا	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	8	nsubj	_	_
 7	تبديل	تبديل	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	8	compound	_	_
-8	ٿيڻي	_	VERB	VM	Aspect=Imp|Gender=Fem|Number=Sing|VerbForm=FutPart	1	obj	_	_
+8	ٿيڻي	_	VERB	VM	Aspect=Imp|Gender=Fem|Number=Sing|VerbForm=FutPart	1	advcl	_	_
 9	ناهي	ناهي	AUX	VAUX	Number=Sing|Tense=Pres	8	aux	_	SpaceAfter=No
 10	،	،	PUNCT	PUNCT	_	8	punct	_	_
 
@@ -11094,7 +11094,7 @@
 10	هئڻ	هئو	VERB	VM	Aspect=Imp|VerbForm=Inf	12	nmod	_	_
 11	جو	جو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Sing	10	mark	_	_
 12	گمان	گمان	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	compound	_	_
-13	ٿئي	ٿي	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	3	obj	_	_
+13	ٿئي	ٿي	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	3	advcl	_	_
 14	ٿو	آهي	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Pres	13	aux	_	SpaceAfter=No
 15	.	.	PUNCT	PUNCT	_	13	punct	_	_
 
@@ -11786,7 +11786,7 @@
 7	ڪتابن	ڪتاب	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	9	nmod	_	_
 8	جا	جو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Plur	7	case	_	_
 9	ترجما	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	10	obj	_	_
-10	ڪيا	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur|Voice=Act	3	obj	_	_
+10	ڪيا	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur|Voice=Act	3	advcl	_	_
 11	ويندا	ويندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Plur|VerbForm=PresPart|Voice=Act	10	compound	_	_
 12	آهن	آهي	AUX	VAUX	Number=Plur|Tense=Pres	10	aux	_	SpaceAfter=No
 13	،	،	PUNCT	PUNCT	_	10	punct	_	_
@@ -12378,7 +12378,7 @@
 9	کي	کي	ADP	PSP	_	8	case	_	_
 10	مالا	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	obj	_	_
 11	مال	مال	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	12	compound	_	_
-12	ڪري	ڪر	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	4	obj	_	_
+12	ڪري	ڪر	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	4	advcl	_	_
 13	ٿو	آهي	AUX	VAUX	Number=Sing|Person=3|Tense=Pres	12	aux	_	SpaceAfter=No
 14	،	،	PUNCT	PUNCT	_	12	punct	_	_
 
@@ -12399,7 +12399,7 @@
 13	کي	کي	ADP	PSP	_	12	case	_	_
 14	عزت	عزت	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	nmod	_	_
 15	دار	دار	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	xcomp	_	_
-16	بنايون	بنائي	VERB	VM	Aspect=Imp|Number=Plur|Person=3|Voice=Act	6	obj	_	_
+16	بنايون	بنائي	VERB	VM	Aspect=Imp|Number=Plur|Person=3|Voice=Act	6	advcl	_	_
 17	۽	۽	CCONJ	CC	_	25	cc	_	_
 18	کيس	کي	ADP	PSPX	Case=Acc|Number=Sing|Person=3	25	nsubj	_	_
 19	ماني	ماني	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	nmod	_	_
@@ -14474,7 +14474,7 @@
 14	ڍءُ	ڍءُ	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	obj	_	_
 15	جهليو	_	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	17	xcomp	_	_
 16	نٿو	نٿو	PART	PART	_	17	dep	_	_
-17	ٿئي	ٿي	VERB	VM	Aspect=Imp|Number=Sing|Person=3	9	obj	_	SpaceAfter=No
+17	ٿئي	ٿي	VERB	VM	Aspect=Imp|Number=Sing|Person=3	9	advcl	_	SpaceAfter=No
 18	.	.	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 4462

--- a/not-to-release/xpos_features/sd_batch_4.800_xpos_labeled_2025-03-18.txt
+++ b/not-to-release/xpos_features/sd_batch_4.800_xpos_labeled_2025-03-18.txt
@@ -1463,7 +1463,7 @@
 16	حساب	حساب	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	19	obl	_	_
 17	۾	۾	ADP	PSPL	_	16	case	_	_
 18	گهٽ	گهٽ	ADJ	JJ	Case=Nom|Degree=Pos	19	xcomp	_	_
-19	ملي	مل	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	4	obj	_	_
+19	ملي	مل	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	4	advcl	_	_
 20	ٿي	آهي	AUX	VAUX	Gender=Fem|Number=Sing|Tense=Pres	19	aux	_	SpaceAfter=No
 21	.	.	PUNCT	PUNCT	_	19	punct	_	_
 
@@ -2389,7 +2389,7 @@
 21	کي	کي	ADP	PSP	_	20	case	_	_
 22	ليز	ليز	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	24	obl	_	_
 23	تي	تي	ADP	PSPL	_	22	case	_	_
-24	ڏني	ڏني	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	3	obj	_	_
+24	ڏني	ڏني	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	3	advcl	_	_
 25	وئي	وئي	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	24	compound	_	_
 26	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	24	aux	_	SpaceAfter=No
 27	.	.	PUNCT	PUNCT	_	24	punct	_	_
@@ -2459,7 +2459,7 @@
 13	جنهن	جنهن	PRON	PRP	Case=Acc|Number=Sing|Person=3	14	det	_	_
 14	تيزي	تيزي	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	obl	_	_
 15	سان	سان	ADP	PSP	_	14	case	_	_
-16	وڌي	وڌي	VERB	VM	Aspect=Imp|Voice=Act	7	obj	_	_
+16	وڌي	وڌي	VERB	VM	Aspect=Imp|Voice=Act	7	advcl	_	_
 17	رهي	ره	VERB	VM	Aspect=Imp|Gender=Fem|Number=Sing|Person=3|Voice=Act	16	compound	_	_
 18	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	16	aux	_	_
 19	ان	ان	DET	PRD	Case=Acc|Number=Sing|Person=3	21	nmod	_	_
@@ -2504,7 +2504,7 @@
 20	گدامن	_	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	23	obj	_	_
 21	کي	کي	ADP	PSP	_	20	case	_	_
 22	ڀريل	_	ADJ	JJ	Degree=Pos|Gender=Masc	23	xcomp	_	_
-23	رکو	رک	VERB	VM	Aspect=Imp|Number=Plur|Person=3	5	obj	_	_
+23	رکو	رک	VERB	VM	Aspect=Imp|Number=Plur|Person=3	5	advcl	_	_
 24	۽	۽	CCONJ	CC	_	33	cc	_	_
 25	ڪيترن	ڪيترو	ADJ	JJ	Case=Acc|Number=Plur	27	amod	_	_
 26	ئي	ئي	PART	PART	_	25	advmod:emph	_	_
@@ -3035,7 +3035,7 @@
 23	وڏو	وڏو	ADJ	JJ	Case=Nom|Degree=Cmp|Gender=Masc|Number=Sing	25	amod	_	_
 24	معاشي	معاشي	ADJ	JJ	Case=Nom|Degree=Pos	25	amod	_	_
 25	فائدو	فائدو	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	26	nsubj	_	_
-26	مليو	مل	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	6	obj	_	_
+26	مليو	مل	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	6	advcl	_	_
 27	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	26	aux	_	_
 28	يا	يا	CCONJ	CC	_	29	cc	_	_
 29	ملندو	_	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	26	conj	_	SpaceAfter=No
@@ -5012,7 +5012,7 @@
 28	ڪرڻ	ڪر	VERB	VM	Aspect=Imp|VerbForm=Inf	31	advcl	_	_
 29	کان	کان	ADP	PSP	_	28	mark	_	_
 30	پاسو	پاسو	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	31	obl	_	_
-31	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	9	obj	_	_
+31	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	9	advcl	_	_
 32	ويندو	ويندو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	31	compound	_	_
 33	ڇو	ڇو	PRON	PRWH	Number=Sing	54	obl	_	_
 34	جو	جو	ADP	PSP	_	33	mark	_	_
@@ -6116,7 +6116,7 @@
 17	حلّوس	حلّوس	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	20	obl	_	_
 18	لاءِ	لاءِ	ADP	PSP	_	17	case	_	_
 19	مقرر	مقرر	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	xcomp	_	_
-20	ڪيا	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	7	obj	_	_
+20	ڪيا	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	7	advcl	_	_
 21	هئا	هئو	AUX	VAUX	Gender=Masc|Number=Plur|Tense=Past	20	aux	_	_
 22	۽	۽	CCONJ	CC	_	37	cc	_	_
 23	شهرن	شهر	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	27	nmod	_	_
@@ -6609,7 +6609,7 @@
 12	هر	هر	DET	PRD	Case=Nom|Number=Sing	13	det	_	_
 13	صوبي	صوبي	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	15	obl	_	_
 14	۾	۾	ADP	PSPL	_	13	case	_	_
-15	ٿين	آھي	VERB	VM	Aspect=Imp|Number=Plur|Person=3|Voice=Act	6	obj	_	_
+15	ٿين	آھي	VERB	VM	Aspect=Imp|Number=Plur|Person=3|Voice=Act	6	advcl	_	_
 16	ٿا	آهي	AUX	VAUX	Gender=Masc|Number=Plur|Tense=Pres	15	aux	_	_
 17	پر	پر	SCONJ	CS	_	15	mark	_	_
 18	اهڙا	اهڙو	ADJ	JJ	Case=Nom|Degree=Pos|Number=Plur	19	amod	_	_
@@ -6688,7 +6688,7 @@
 8	فيصد	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nmod	_	_
 9	ٽيڪس	_	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	11	obj	_	_
 10	تا	_	ADP	PSPL	_	11	xcomp	_	_
-11	ڏيون	_	VERB	VM	Aspect=Imp|Number=Plur|Person=3	3	obj	_	_
+11	ڏيون	_	VERB	VM	Aspect=Imp|Number=Plur|Person=3	3	advcl	_	_
 12	ته	ته	SCONJ	CS	_	24	mark	_	_
 13	پوءِ	پوءِ	ADP	PSP	_	24	advmod	_	_
 14	اسان	اسين	PRON	PRP	Case=Acc|Number=Plur|Person=1	16	nmod	_	_
@@ -8561,7 +8561,7 @@
 30	تيزي	تيزي	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	33	obl	_	_
 31	سان	سان	ADP	PSP	_	30	case	_	_
 32	اڳتي	اڳتي	ADV	ADP	_	33	advmod	_	_
-33	وڌي	وڌي	VERB	VM	Aspect=Imp|Voice=Act	22	obj	_	_
+33	وڌي	وڌي	VERB	VM	Aspect=Imp|Voice=Act	22	advcl	_	_
 34	رهي	ره	VERB	VM	Aspect=Imp|Number=Sing|Person=3	33	compound	_	_
 35	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	33	aux	_	SpaceAfter=No
 36	،	،	PUNCT	PUNCT	_	33	punct	_	_
@@ -9370,7 +9370,7 @@
 29	جذبا	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	30	obj	_	_
 30	کڻي	کڻي	VERB	VM	Aspect=Perf|VerbForm=Conv	32	advcl	_	_
 31	پاڪستان	پاڪستان	PROPN	NNP	Case=Nom|Gender=Masc	32	obl	_	_
-32	آئي	آئي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing|Person=3	23	obj	_	_
+32	آئي	آئي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing|Person=3	23	advcl	_	_
 33	۽	۽	CCONJ	CC	_	40	cc	_	_
 34	اوباما	اوباما	PROPN	NNP	Case=Nom|Gender=Masc	37	nmod	_	_
 35	جا	جو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Plur	34	case	_	_
@@ -9659,7 +9659,7 @@
 22	بدنامي	بدنامي	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	24	nmod	_	_
 23	جو	جو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Sing	22	case	_	_
 24	سبب	سبب	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	25	xcomp	_	_
-25	هوندو	هوندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	8	obj	_	_
+25	هوندو	هوندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	8	advcl	_	_
 26	پر	پر	SCONJ	CS	_	25	mark	_	_
 27	اسان	اسين	PRON	PRP	Case=Acc|Number=Plur|Person=1	30	nmod	_	_
 28	جي	جي	ADP	PSPG	Case=Acc|Gender=Fem|Number=Sing	27	case	_	_
@@ -9841,7 +9841,7 @@
 27	مون	مون	PRON	PRP	Case=Acc|Number=Sing|Person=1	30	obl	_	_
 28	مٿان	مٿي	ADV	ADP	_	30	advmod	_	_
 29	تنقيد	تنقيد	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	30	xcomp	_	_
-30	ڪئي	ڪئي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing|Person=3	16	obj	_	_
+30	ڪئي	ڪئي	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing|Person=3	16	advcl	_	_
 31	۽	۽	CCONJ	CC	_	32	cc	_	_
 32	چيو	چئو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	30	conj	_	_
 33	ويو	ويو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	32	compound	_	_
@@ -9854,7 +9854,7 @@
 40	شريف	شريف	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	42	nmod	_	_
 41	جو	جو	ADP	PSPG	Case=Acc|Gender=Masc|Number=Sing	40	case	_	_
 42	گراف	گراف	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	43	nsubj:pass	_	_
-43	گهٽجي	گهٽج	VERB	VM	Aspect=Imp|Voice=Pass	32	obj	_	_
+43	گهٽجي	گهٽج	VERB	VM	Aspect=Imp|Voice=Pass	32	advcl	_	_
 44	ويو	ويو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	43	compound	_	_
 45	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	43	aux	_	SpaceAfter=No
 46	،	،	PUNCT	PUNCT	_	43	punct	_	_
@@ -10127,7 +10127,7 @@
 21	پئڪيج	_	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	nmod	_	_
 22	جو	جو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Sing	21	case	_	_
 23	اعلان	اعلان	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	xcomp	_	_
-24	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	7	obj	_	_
+24	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	7	advcl	_	_
 25	وئي	وئي	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	24	compound	_	_
 26	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	24	aux	_	SpaceAfter=No
 27	،	،	PUNCT	PUNCT	_	24	punct	_	_
@@ -10575,7 +10575,7 @@
 69	مهينا	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	70	nmod	_	_
 70	اڳ	اڳ	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	72	obj	_	_
 71	تيار	تيار	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	72	xcomp	_	_
-72	ڪرڻ	ڪر	VERB	VM	Aspect=Imp|VerbForm=Inf	53	obj	_	_
+72	ڪرڻ	ڪر	VERB	VM	Aspect=Imp|VerbForm=Inf	53	advcl	_	_
 73	گهرجن	گهرجي	VERB	VM	Aspect=Imp|Number=Plur|Person=3	72	compound	_	_
 74	ته	ته	SCONJ	CS	_	87	mark	_	_
 75	جيئن	جيئن	ADV	ADM	_	87	advmod	_	_
@@ -11106,7 +11106,7 @@
 12	مليل	مليو	VERB	VM	Aspect=Perf|VerbForm=PastPart	13	acl	_	_
 13	رپورٽن	_	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	obl	_	_
 14	۾	۾	ADP	PSPL	_	13	case	_	_
-15	چيو	چئو	VERB	VM	Aspect=Perf|Number=Sing	3	obj	_	_
+15	چيو	چئو	VERB	VM	Aspect=Perf|Number=Sing	3	advcl	_	_
 16	ويو	ويو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	15	compound	_	_
 17	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	15	aux	_	_
 18	ته	ته	SCONJ	CS	_	34	mark	_	_
@@ -11125,7 +11125,7 @@
 31	حملا	حملو	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	32	compound	_	_
 32	ڪرڻ	ڪر	VERB	VM	Aspect=Imp|VerbForm=Inf	34	advcl	_	_
 33	طرف	طرف	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	34	obl	_	_
-34	وڌائي	وڌاءِ	VERB	VM	Aspect=Imp|Voice=Act	15	obj	_	_
+34	وڌائي	وڌاءِ	VERB	VM	Aspect=Imp|Voice=Act	15	advcl	_	_
 35	رهيا	ره	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	34	compound	_	_
 36	آهن	آهي	AUX	VAUX	Number=Plur|Tense=Pres	34	aux	_	SpaceAfter=No
 37	،	،	PUNCT	PUNCT	_	34	punct	_	_
@@ -11234,7 +11234,7 @@
 16	مقصدن	_	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	19	obl	_	_
 17	لاءِ	لاءِ	ADP	PSP	_	16	case	_	_
 18	استعمال	استعمال	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	19	compound	_	_
-19	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	3	obj	_	_
+19	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	3	advcl	_	_
 20	سگهن	سگهي	AUX	VAUX	Number=Plur|Person=3	19	aux	_	_
 21	ٿيون	ٿي	AUX	VAUX	Gender=Masc|Number=Plur|Tense=Pres	19	aux	_	SpaceAfter=No
 22	.	.	PUNCT	PUNCT	_	19	punct	_	_
@@ -11613,7 +11613,7 @@
 20	ڪرڻ	ڪر	VERB	VM	Aspect=Imp|VerbForm=Inf	22	nmod	_	_
 21	جي	جي	ADP	PSPG	Case=Nom|Gender=Fem|Number=Sing	20	mark	_	_
 22	رٿابندي	_	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	23	obl	_	_
-23	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	8	obj	_	_
+23	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	8	advcl	_	_
 24	رهيا	ره	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	23	compound	_	_
 25	هئا	هئو	AUX	VAUX	Number=Plur|Tense=Past	23	aux	_	SpaceAfter=No
 26	.	.	PUNCT	PUNCT	_	23	punct	_	_
@@ -12174,7 +12174,7 @@
 64	اختيار	اختيار	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	67	obj	_	_
 65	بحال	_	NOUN	NN	Case=Nom|Number=Sing	67	xcomp	_	_
 66	نه	نه	PART	PART	_	67	dep	_	_
-67	ٿيا	ٿيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	56	obj	_	_
+67	ٿيا	ٿيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	56	advcl	_	_
 68	آهن	آهي	AUX	VAUX	Number=Plur|Tense=Pres	67	aux	_	SpaceAfter=No
 69	.	.	PUNCT	PUNCT	_	67	punct	_	_
 
@@ -12390,7 +12390,7 @@
 13	نوٽيفڪيشن	نوٽيفڪيشن	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	obj	_	_
 14	واپس	واپس	VERB	VM	Aspect=Imp|Voice=Act	16	compound	_	_
 15	نٿو	نٿو	PART	PART	_	16	dep	_	_
-16	ورتو	ورتو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	6	obj	_	_
+16	ورتو	ورتو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	6	advcl	_	_
 17	وڃي	وڃ	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	16	compound	_	SpaceAfter=No
 18	،	،	PUNCT	PUNCT	_	16	punct	_	_
 
@@ -12677,7 +12677,7 @@
 25	ڪندي	ڪن	VERB	VM	Aspect=Imp	28	advcl	_	_
 26	گهٽين	_	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	28	obl	_	_
 27	۾	۾	ADP	PSPL	_	26	case	_	_
-28	ويندا	ويندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Plur	14	obj	_	_
+28	ويندا	ويندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Plur	14	advcl	_	_
 29	رهيا	ره	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	28	compound	_	_
 30	جڏهن	جڏهن	ADV	ADT	_	43	advmod	_	_
 31	ته	ته	SCONJ	CS	_	28	mark	_	_
@@ -14404,7 +14404,7 @@
 45	کي	کي	ADP	PSP	_	44	case	_	_
 46	الڳ	الڳ	ADJ	JJ	Case=Nom|Degree=Pos	48	compound	_	_
 47	ناهي	ناهي	AUX	VAUX	Person=3|Tense=Pres	48	aux	_	_
-48	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	30	obj	_	SpaceAfter=No
+48	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	30	advcl	_	SpaceAfter=No
 49	،	،	PUNCT	PUNCT	_	48	punct	_	_
 
 # sent_id = 5016
@@ -14827,7 +14827,7 @@
 63	کان	کان	ADP	PSP	_	62	case	_	_
 64	اڳ	اڳ	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	66	obl	_	_
 65	رقم	رقم	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	66	obj	_	_
-66	ڏني	ڏني	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	49	obj	_	_
+66	ڏني	ڏني	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	49	advcl	_	_
 67	ويندي	ويندو	VERB	VM	Aspect=Imp|Number=Sing|Person=3	66	compound	_	SpaceAfter=No
 68	،	،	PUNCT	PUNCT	_	66	punct	_	_
 
@@ -15075,7 +15075,7 @@
 35	ميگاواٽ	_	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	36	nmod	_	_
 36	بجلي	بجلي	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	38	nsubj	_	_
 37	بچت	بچت	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	38	compound	_	_
-38	ٿيندي	ٿي	VERB	VM	Aspect=Imp|Gender=Fem|Number=Sing|VerbForm=PresPart	24	obj	_	_
+38	ٿيندي	ٿي	VERB	VM	Aspect=Imp|Gender=Fem|Number=Sing|VerbForm=PresPart	24	advcl	_	_
 39	هئي	آهي	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Past	38	aux	_	SpaceAfter=No
 40	،	،	PUNCT	PUNCT	_	38	punct	_	_
 
@@ -15191,7 +15191,7 @@
 55	جي	جي	ADP	PSPG	Case=Nom|Gender=Fem|Number=Sing	54	case	_	_
 56	پاليسي	پاليسي	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	57	obj	_	_
 57	ٺاهڻ	ٺاه	VERB	VM	Aspect=Imp|VerbForm=Inf	58	xcomp	_	_
-58	چاهي	چاه	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	32	obj	_	_
+58	چاهي	چاه	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	32	advcl	_	_
 59	ٿي	آهي	AUX	VAUX	Number=Sing|Person=3|Tense=Pres	58	aux	_	SpaceAfter=No
 60	،	،	PUNCT	PUNCT	_	58	punct	_	_
 
@@ -15550,7 +15550,7 @@
 9	عدالت	عدالت	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	12	obl	_	_
 10	۾	۾	ADP	PSPL	_	9	case	_	_
 11	چيلينج	چيلينج	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	12	xcomp	_	_
-12	ٿيل	ٿيو	VERB	VM	Aspect=Perf|Number=Sing	1	obj	_	_
+12	ٿيل	ٿيو	VERB	VM	Aspect=Perf|Number=Sing	1	advcl	_	_
 13	آهي	آهي	AUX	VAUX	Number=Sing|Person=3|Tense=Pres	12	aux	_	SpaceAfter=No
 14	،	،	PUNCT	PUNCT	_	12	punct	_	_
 
@@ -16666,7 +16666,7 @@
 9	۾	۾	ADP	PSPL	_	8	mark	_	_
 10	قمبر	قمبر	PROPN	NNP	Case=Nom|Gender=Masc	12	obl	_	_
 11	۾	۾	ADP	PSPL	_	10	case	_	_
-12	رهندو	ره	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart	4	obj	_	_
+12	رهندو	ره	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart	4	advcl	_	_
 13	هئس	هئو	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Past	12	aux	_	SpaceAfter=No
 14	،	،	PUNCT	PUNCT	_	12	punct	_	_
 15	هاڻي	هاڻ	ADV	ADT	_	23	advmod	_	_
@@ -16824,7 +16824,7 @@
 12	تي	تي	ADP	PSPL	_	11	case	_	_
 13	ساڻس	_	ADV	ADPX	_	15	advmod	_	_
 14	تڪرار	تڪرار	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	xcomp	_	_
-15	هلندڙ	هل	VERB	VM	Aspect=Imp|VerbForm=Vnoun	4	obj	_	_
+15	هلندڙ	هل	VERB	VM	Aspect=Imp|VerbForm=Vnoun	4	advcl	_	_
 16	هو	هو	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Past	15	aux	_	SpaceAfter=No
 17	،	،	PUNCT	PUNCT	_	15	punct	_	_
 
@@ -17053,7 +17053,7 @@
 17	جي	جي	ADP	PSPG	Case=Nom|Gender=Fem|Number=Sing	18	nmod	_	_
 18	ڌر	ڌر	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	20	obj	_	_
 19	نه	نه	PART	PART	_	20	dep	_	_
-20	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	10	obj	_	_
+20	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	10	advcl	_	_
 21	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	20	aux	_	SpaceAfter=No
 22	،	،	PUNCT	PUNCT	_	20	punct	_	_
 
@@ -17109,7 +17109,7 @@
 17	هاري	هاري	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	20	obj	_	_
 18	کي	کي	ADP	PSP	_	17	case	_	_
 19	قتل	قتل	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	compound	_	_
-20	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	10	obj	_	_
+20	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	10	advcl	_	_
 21	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	20	aux	_	SpaceAfter=No
 22	،	،	PUNCT	PUNCT	_	20	punct	_	_
 
@@ -17898,7 +17898,7 @@
 30	ليبارٽري	_	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	33	obl	_	_
 31	ڏانهن	ڏانهن	ADV	ADP	_	30	case	_	_
 32	جزا	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	33	obj	_	_
-33	اماڻيا	_	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	9	obj	_	_
+33	اماڻيا	_	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	9	advcl	_	_
 34	آهن	آهي	AUX	VAUX	Number=Plur|Tense=Pres	33	aux	_	SpaceAfter=No
 35	،	،	PUNCT	PUNCT	_	33	punct	_	_
 
@@ -18145,7 +18145,7 @@
 20	بخش	بخش	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	obj	_	_
 21	کي	کي	ADP	PSP	_	20	case	_	_
 22	قتل	_	ADJ	JJ	Case=Nom	23	compound	_	_
-23	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	13	obj	_	_
+23	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	13	advcl	_	_
 24	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	23	aux	_	SpaceAfter=No
 25	،	،	PUNCT	PUNCT	_	23	punct	_	_
 
@@ -18519,7 +18519,7 @@
 46	ڪاررواين	ڪارروائي	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	48	nmod	_	_
 47	جو	جو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Sing	46	case	_	_
 48	نشانو	نشانو	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	49	xcomp	_	_
-49	بڻائي	بڻاءِ	VERB	VM	Aspect=Imp|Voice=Act	32	obj	_	_
+49	بڻائي	بڻاءِ	VERB	VM	Aspect=Imp|Voice=Act	32	advcl	_	_
 50	رهي	ره	VERB	VM	Aspect=Imp|Number=Sing|Person=3	49	compound	_	_
 51	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	49	aux	_	SpaceAfter=No
 52	.	.	PUNCT	PUNCT	_	49	punct	_	_
@@ -20423,7 +20423,7 @@
 16	مون	مون	PRON	PRP	Case=Acc|Number=Sing|Person=1	19	obl	_	_
 17	کان	کان	ADP	PSP	_	16	case	_	_
 18	واپس	واپس	NOUN	NN	Case=Nom	19	compound	_	_
-19	ورتا	ورتو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	9	obj	_	_
+19	ورتا	ورتو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur	9	advcl	_	_
 20	وڃن	وڃ	VERB	VM	Aspect=Imp|Number=Plur|Person=3	19	compound	_	SpaceAfter=No
 21	،	،	PUNCT	PUNCT	_	19	punct	_	_
 
@@ -20763,7 +20763,7 @@
 33	تباهي	_	ADJ	JJ	Case=Nom|Degree=Pos|Number=Sing	34	amod	_	_
 34	ڪناري	ڪنارو	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	36	obl	_	_
 35	تي	تي	ADP	PSPL	_	34	case	_	_
-36	پهتل	_	VERB	VM	Aspect=Imp|Voice=Act	14	obj	_	_
+36	پهتل	_	VERB	VM	Aspect=Imp|Voice=Act	14	advcl	_	_
 37	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	36	aux	_	SpaceAfter=No
 38	،	،	PUNCT	PUNCT	_	36	punct	_	_
 
@@ -22092,7 +22092,7 @@
 13	پاڻي	پاڻي	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	obj	_	_
 14	وارڻ	_	VERB	VM	Aspect=Imp|VerbForm=Inf	16	advcl	_	_
 15	لاءِ	لاءِ	ADP	PSP	_	16	mark	_	_
-16	چيو	چئو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	6	obj	_	_
+16	چيو	چئو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	6	advcl	_	_
 17	جنهن	جنهن	PRON	PRP	Case=Acc|Number=Sing|Person=3	20	obl	_	_
 18	تان	تان	ADP	PSPL	_	20	mark	_	_
 19	انڪار	انڪار	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	20	obl	_	_
@@ -23018,7 +23018,7 @@
 20	آبادگارن	آبادگار	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	18	conj	_	_
 21	کي	کي	ADP	PSP	_	18	case	_	_
 22	فائدو	فائدو	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	23	xcomp	_	_
-23	ملي	مل	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	2	obj	_	_
+23	ملي	مل	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	2	advcl	_	_
 24	سگھي	سگھي	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Pres	23	aux	_	SpaceAfter=No
 25	،	،	PUNCT	PUNCT	_	23	punct	_	_
 

--- a/not-to-release/xpos_features/sd_batch_5_600.conllu
+++ b/not-to-release/xpos_features/sd_batch_5_600.conllu
@@ -131,7 +131,7 @@
 28	الڳ	الڳ	ADJ	JJ	Case=Nom|Degree=Pos	29	amod	_	_
 29	بجيٽ	بجيٽ	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	31	obj	_	_
 30	نه	نه	PART	PART	_	31	dep	_	_
-31	رکڻي	_	VERB	VM	Aspect=Imp|Voice=Act	20	obj	_	_
+31	رکڻي	_	VERB	VM	Aspect=Imp|Voice=Act	20	advcl	_	_
 32	پوي	پو	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	31	compound	_	SpaceAfter=No
 33	!!	_	PUNCT	PUNCT	_	31	punct	_	_
 34	پر	پر	SCONJ	CS	_	31	mark	_	_
@@ -147,7 +147,7 @@
 44	صورتحال	صورتحال	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	47	obl	_	_
 45	۾	۾	ADP	PSPL	_	44	case	_	_
 46	نه	نه	PART	PART	_	47	dep	_	_
-47	وينداسين	ويندو	VERB	VM	Aspect=Imp|Number=Plur	37	obj	_	_
+47	وينداسين	ويندو	VERB	VM	Aspect=Imp|Number=Plur	37	advcl	_	_
 48	جو	جو	ADP	PSP	_	47	mark	_	_
 49	اسان	اسين	PRON	PRP	Case=Acc|Number=Plur|Person=1	55	nsubj	_	_
 50	کي	کي	ADP	PSP	_	49	case	_	_
@@ -440,7 +440,7 @@
 12	ڌارين	ڌاريون	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	15	obj	_	_
 13	کي	کي	ADP	PSP	_	12	case	_	_
 14	نيڪالي	نيڪالي	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	compound	_	_
-15	ڏني	ڏني	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	2	obj	_	_
+15	ڏني	ڏني	VERB	VM	Aspect=Perf|Gender=Fem|Number=Sing	2	advcl	_	_
 16	وڃي	وڃ	VERB	VM	Aspect=Imp|Number=Sing|Person=3	15	compound	_	SpaceAfter=No
 17	،	،	PUNCT	PUNCT	_	15	punct	_	_
 
@@ -853,7 +853,7 @@
 20	ميسيج	_	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	21	compound	_	_
 21	ڪري	ڪر	VERB	VM	Aspect=Perf|VerbForm=Conv	23	advcl	_	_
 22	ڌمڪيون	ڌمڪي	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	23	obj	_	_
-23	ڏئي	ڏئي	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	9	obj	_	_
+23	ڏئي	ڏئي	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	9	advcl	_	_
 24	ٿو	آهي	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Pres	23	aux	_	_
 25	۽	۽	CCONJ	CC	_	31	cc	_	_
 26	گهر	گهر	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	31	obl	_	_
@@ -1202,7 +1202,7 @@
 31	اقليت	_	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	34	obl	_	_
 32	۾	۾	ADP	PSPL	_	31	case	_	_
 33	تبديل	تبديل	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	34	xcomp	_	_
-34	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	16	obj	_	_
+34	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	16	advcl	_	_
 35	رهي	ره	VERB	VM	Aspect=Imp|Number=Sing|Person=3	34	compound	_	_
 36	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	34	aux	_	_
 37	ڇو	ڇو	ADV	ADT	_	42	advmod	_	_
@@ -1748,7 +1748,7 @@
 58	ان	ان	DET	PRD	Case=Acc|Number=Sing	59	det	_	_
 59	نتيجي	نتيجو	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	61	obl	_	_
 60	تي	تي	ADP	PSPL	_	59	case	_	_
-61	پهتي	پهتو	VERB	VM	Aspect=Perf|Number=Sing	34	obj	_	_
+61	پهتي	پهتو	VERB	VM	Aspect=Perf|Number=Sing	34	advcl	_	_
 62	آهيان	آهي	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Pres	61	aux	_	_
 63	ته	ته	SCONJ	CS	_	73	mark	_	_
 64	پاڪ	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	65	compound	_	_
@@ -1907,7 +1907,7 @@
 31	جي	جي	ADP	PSPG	Case=Nom|Gender=Fem|Number=Sing	30	case	_	_
 32	ڏي	ڏي	VERB	VM	Aspect=Perf	34	compound	_	_
 33	وٺ	وٺ	VERB	VM	Aspect=Imp	34	compound	_	_
-34	ڪرڻ	ڪر	VERB	VM	Aspect=Imp|VerbForm=Inf	2	obj	_	_
+34	ڪرڻ	ڪر	VERB	VM	Aspect=Imp|VerbForm=Inf	2	advcl	_	_
 35	هو	هو	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Past	34	aux	_	SpaceAfter=No
 36	،	،	PUNCT	PUNCT	_	34	punct	_	_
 
@@ -2068,7 +2068,7 @@
 25	تي	تي	ADP	PSPL	_	24	case	_	_
 26	جلد	جلد	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	28	obl	_	_
 27	عمل	عمل	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	28	compound	_	_
-28	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	18	obj	_	_
+28	ڪيو	ڪيو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	18	advcl	_	_
 29	ويندو	ويندو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3|Voice=Act	28	compound	_	SpaceAfter=No
 30	،	،	PUNCT	PUNCT	_	28	punct	_	_
 
@@ -4170,7 +4170,7 @@
 20	سان	سان	ADP	PSP	_	19	case	_	_
 21	جنسي	_	ADJ	JJ	Case=Nom|Degree=Pos	22	amod	_	_
 22	ڏاڍائي	ڏاڍ	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	23	compound	_	_
-23	ڪندا	ڪن	VERB	VM	Aspect=Imp|Gender=Masc|Number=Plur|Voice=Act	6	obj	_	_
+23	ڪندا	ڪن	VERB	VM	Aspect=Imp|Gender=Masc|Number=Plur|Voice=Act	6	advcl	_	_
 24	رهيا	ره	VERB	VM	Aspect=Perf|Gender=Masc|Number=Plur|Voice=Act	23	compound	_	_
 25	آهن	آهي	AUX	VAUX	Number=Plur|Tense=Pres	23	aux	_	SpaceAfter=No
 26	،	،	PUNCT	PUNCT	_	23	punct	_	_
@@ -4579,7 +4579,7 @@
 21	مقبوليت	مقبوليت	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	nmod	_	_
 22	جو	جو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Sing	21	case	_	_
 23	گراف	گراف	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	obj	_	_
-24	ڪيرائي	_	VERB	VM	Aspect=Imp|Voice=Act	6	obj	_	_
+24	ڪيرائي	_	VERB	VM	Aspect=Imp|Voice=Act	6	advcl	_	_
 25	رهي	ره	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3|Voice=Act	24	compound	_	_
 26	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	24	aux	_	SpaceAfter=No
 27	،	،	PUNCT	PUNCT	_	24	punct	_	_
@@ -6425,7 +6425,7 @@
 6	لوڙهي	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
 7	اجهو	اجهو	ADV	ADM	_	9	advmod	_	_
 8	چريو	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	xcomp	_	_
-9	ٿيڻ	ٿي	VERB	VM	Aspect=Imp|VerbForm=Inf	2	obj	_	_
+9	ٿيڻ	ٿي	VERB	VM	Aspect=Imp|VerbForm=Inf	2	advcl	_	_
 10	وارو	وارو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Sing	9	mark	_	_
 11	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	9	aux	_	SpaceAfter=No
 12	.	.	PUNCT	PUNCT	_	9	punct	_	_
@@ -9246,7 +9246,7 @@
 17	(	(	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 18	وظيفو	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	conj	_	SpaceAfter=No
 19	)	)	PUNCT	PUNCT	_	18	punct	_	_
-20	ڏنو	ڏنو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	3	obj	_	_
+20	ڏنو	ڏنو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	3	advcl	_	_
 21	ويندو	ويندو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	20	compound	_	SpaceAfter=No
 22	.	.	PUNCT	PUNCT	_	20	punct	_	_
 
@@ -9633,7 +9633,7 @@
 10	سڪرنڊ	_	PROPN	NNP	Case=Nom|Gender=Masc	8	conj	_	_
 11	جي	جي	ADP	PSPG	Case=Acc|Gender=Masc|Number=Sing	8	case	_	_
 12	سامهون	سامهون	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	obl	_	_
-13	ٺاهي	ٺاه	VERB	VM	Aspect=Perf	3	obj	_	_
+13	ٺاهي	ٺاه	VERB	VM	Aspect=Perf	3	advcl	_	_
 14	وڃي	وڃ	VERB	VM	Aspect=Imp|Number=Sing|Person=3	13	compound	_	SpaceAfter=No
 15	،	،	PUNCT	PUNCT	_	13	punct	_	_
 
@@ -9652,7 +9652,7 @@
 11	احمد	احمد	PROPN	NNP	Case=Nom|Gender=Masc	8	conj	_	_
 12	جي	جي	ADP	PSPG	Case=Acc|Gender=Masc|Number=Sing	8	case	_	_
 13	سامهون	سامهون	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	obl	_	_
-14	ٺاهي	ٺاه	VERB	VM	Aspect=Perf	3	obj	_	_
+14	ٺاهي	ٺاه	VERB	VM	Aspect=Perf	3	advcl	_	_
 15	وڃي	وڃ	VERB	VM	Aspect=Imp|Number=Sing|Person=3	14	compound	_	SpaceAfter=No
 16	.	.	PUNCT	PUNCT	_	14	punct	_	_
 
@@ -9694,7 +9694,7 @@
 7	تي	تي	ADP	PSPL	_	6	case	_	_
 8	بحث	بحث	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	compound	_	_
 9	ڪرڻ	ڪر	VERB	VM	Aspect=Imp|VerbForm=Inf	10	xcomp	_	_
-10	اجايو	_	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	2	obj	_	_
+10	اجايو	_	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	2	advcl	_	_
 11	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	10	aux	_	SpaceAfter=No
 12	،	،	PUNCT	PUNCT	_	10	punct	_	_
 
@@ -10895,7 +10895,7 @@
 11	طبلي	طبلي	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	14	obl	_	_
 12	تي	تي	ADP	PSPL	_	11	case	_	_
 13	عبور	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	compound	_	_
-14	هوندو	هوندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	5	obj	_	_
+14	هوندو	هوندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	5	advcl	_	_
 15	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	14	aux	_	SpaceAfter=No
 16	،	،	PUNCT	PUNCT	_	14	punct	_	_
 
@@ -11256,7 +11256,7 @@
 29	خلاف	خلاف	ADP	PSP	_	26	mark	_	_
 30	قانوني	_	NOUN	NN	Case=Nom|Number=Sing	31	nmod	_	_
 31	ڪارروائي	ڪارروائي	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	32	compound	_	_
-32	ڪئي	ڪئي	VERB	VM	Aspect=Perf|Number=Sing	16	obj	_	_
+32	ڪئي	ڪئي	VERB	VM	Aspect=Perf|Number=Sing	16	advcl	_	_
 33	وڃي	وڃ	VERB	VM	Aspect=Imp|Number=Sing|Person=3	32	compound	_	SpaceAfter=No
 34	،	،	PUNCT	PUNCT	_	32	punct	_	_
 
@@ -12509,7 +12509,7 @@
 36	مارئي	مارئي	PROPN	NNP	Case=Nom|Gender=Fem	38	nmod	_	_
 37	جو	جو	ADP	PSPG	Case=Nom|Gender=Masc|Number=Sing	36	case	_	_
 38	ميلو	ميلو	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	39	obj	_	_
-39	ملهايو	ملها	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Voice=Act	9	obj	_	_
+39	ملهايو	ملها	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Voice=Act	9	advcl	_	_
 40	وڃي	وڃ	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	39	compound	_	SpaceAfter=No
 41	.	.	PUNCT	PUNCT	_	39	punct	_	_
 
@@ -12793,7 +12793,7 @@
 25	پاڻي	پاڻي	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	26	obj	_	_
 26	ڀريندي	ڀر	VERB	VM	Aspect=Imp|Number=Sing|VerbForm=PresPart	28	advcl	_	_
 27	زوري	زوري	ADV	ADM	_	28	advmod	_	_
-28	کڻي	کڻي	VERB	VM	Aspect=Perf|VerbForm=Conv	1	obj	_	_
+28	کڻي	کڻي	VERB	VM	Aspect=Perf|VerbForm=Conv	1	advcl	_	_
 29	ويو	ويو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	28	compound	_	_
 30	هو	هو	AUX	VAUX	Number=Sing|Tense=Past	28	aux	_	SpaceAfter=No
 31	.	.	PUNCT	PUNCT	_	28	punct	_	_
@@ -13117,7 +13117,7 @@
 21	وارث	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
 22	سخت	سخت	ADJ	JJ	Case=Nom|Degree=Pos	23	amod	_	_
 23	پريشان	_	NOUN	NN	Case=Nom	24	xcomp	_	_
-24	هوندا	هوندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Plur|VerbForm=PresPart|Voice=Act	10	obj	_	_
+24	هوندا	هوندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Plur|VerbForm=PresPart|Voice=Act	10	advcl	_	_
 25	آهن	آهي	AUX	VAUX	Number=Plur|Tense=Pres	24	aux	_	SpaceAfter=No
 26	،	،	PUNCT	PUNCT	_	24	punct	_	_
 
@@ -13434,7 +13434,7 @@
 15	جاني	_	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	nmod	_	_
 16	نقصان	نقصان	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	obj	_	_
 17	نه	نه	PART	PART	_	18	dep	_	_
-18	ٿيو	ٿي	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	8	obj	_	_
+18	ٿيو	ٿي	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	8	advcl	_	_
 19	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	18	aux	_	SpaceAfter=No
 20	.	.	PUNCT	PUNCT	_	18	punct	_	_
 
@@ -13454,7 +13454,7 @@
 12	عملي	عملي	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	14	nmod	_	_
 13	جي	جي	ADP	PSPG	Case=Nom|Gender=Fem|Number=Sing	12	case	_	_
 14	فهرست	_	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	obj	_	_
-15	ملي	مل	VERB	VM	Aspect=Imp	4	obj	_	_
+15	ملي	مل	VERB	VM	Aspect=Imp	4	advcl	_	_
 16	وئي	وئي	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	15	compound	_	_
 17	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	15	aux	_	SpaceAfter=No
 18	،	،	PUNCT	PUNCT	_	15	punct	_	_
@@ -13515,7 +13515,7 @@
 30	ھاڻي	ھاڻ	ADV	ADT	_	33	advmod	_	_
 31	مختلف	مختلف	ADJ	JJ	Case=Nom|Degree=Pos	32	amod	_	_
 32	زندگي	زندگي	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	33	obj	_	_
-33	گذاري	گذار	VERB	VM	Aspect=Imp|Voice=Act	26	obj	_	_
+33	گذاري	گذار	VERB	VM	Aspect=Imp|Voice=Act	26	advcl	_	_
 34	رھيو	_	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	33	compound	_	_
 35	آھيان	آهي	AUX	VAUX	Number=Sing|Person=1|Tense=Pres	33	aux	_	SpaceAfter=No
 36	،	،	PUNCT	PUNCT	_	33	punct	_	_
@@ -13590,14 +13590,14 @@
 15	تو	تو	PRON	PRP	Case=Acc|Number=Sing|Person=2	18	iobj	_	_
 16	کي	کي	ADP	PSP	_	15	case	_	_
 17	ڪنھن	_	PRON	PRWH	Case=Acc|Number=Sing	18	nsubj	_	_
-18	ٻڌايو	ٻڌاءِ	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	2	obj	_	_
+18	ٻڌايو	ٻڌاءِ	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing	2	advcl	_	_
 19	آھي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	18	aux	_	_
 20	ته	ته	SCONJ	CS	_	25	mark	_	_
 21	تون	تون	PRON	PRP	Case=Nom|Number=Sing|Person=2	25	nsubj	_	_
 22	جارج	_	PROPN	NNP	Case=Nom|Gender=Masc	23	compound	_	_
 23	بش	بش	PROPN	NNP	Case=Nom|Gender=Masc	25	obl	_	_
 24	جھڙو	_	PRON	PRWH	Case=Nom|Gender=Masc|Number=Sing	25	obl	_	_
-25	لڳين	لڳ	VERB	VM	Aspect=Imp|Number=Sing|Person=3	18	obj	_	_
+25	لڳين	لڳ	VERB	VM	Aspect=Imp|Number=Sing|Person=3	18	advcl	_	_
 26	ٿو	آهي	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Pres	25	aux	_	SpaceAfter=No
 27	،	،	PUNCT	PUNCT	_	25	punct	_	_
 

--- a/not-to-release/xpos_features/sd_long_sentences_retokenized.conllu
+++ b/not-to-release/xpos_features/sd_long_sentences_retokenized.conllu
@@ -456,7 +456,7 @@
 27	مارڪيٽ	مارڪيٽ	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	30	obl	_	_
 28	۾	۾	ADP	PSPL	_	27	case	_	_
 29	باهه	باهه	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	30	compound	_	_
-30	ڏني	ڏني	VERB	VM	Aspect=Perf|Number=Sing|Tense=Pres|Voice=Act	6	obj	_	_
+30	ڏني	ڏني	VERB	VM	Aspect=Perf|Number=Sing|Tense=Pres|Voice=Act	6	advcl	_	_
 31	وڃي	وڃ	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Tense=Pres|Voice=Act	30	compound	_	_
 32	ٿي	آهي	AUX	VAUX	Gender=Fem|Number=Sing|Person=3|Tense=Pres	30	aux	_	SpaceAfter=No
 33	۔	_	PUNCT	PUNCT	_	30	punct	_	_

--- a/not-to-release/xpos_features/sd_punct_batch_p2_labeled_2025-04-16.txt
+++ b/not-to-release/xpos_features/sd_punct_batch_p2_labeled_2025-04-16.txt
@@ -378,7 +378,7 @@
 32	وقت	وقت	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	35	nsubj	_	_
 33	تمام	تمام	ADV	ADV	_	34	advmod	_	_
 34	سڀاڳو	_	ADJ	JJ	Case=Nom|Degree=Pos|Gender=Masc|Number=Sing	35	xcomp	_	_
-35	هوندو	هوندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	25	obj	_	_
+35	هوندو	هوندو	VERB	VM	Aspect=Imp|Gender=Masc|Number=Sing|VerbForm=PresPart|Voice=Act	25	advcl	_	_
 36	آهي	آهي	AUX	VAUX	Number=Sing|Tense=Pres	35	aux	_	SpaceAfter=No
 37	.	.	PUNCT	PUNCT	_	35	punct	_	_
 
@@ -962,7 +962,7 @@
 14	اٿئي	آهي	AUX	VAUXX	AuxType=Be|Number=Sing|Person=2	13	aux	_	_
 15	ته	ته	SCONJ	CS	_	17	mark	_	_
 16	آءٌ	آءٌ	PRON	PRP	Case=Nom|Number=Sing|Person=1	17	nsubj	_	_
-17	هارائي	_	VERB	VM	Aspect=Perf|VerbForm=Conv	13	obj	_	_
+17	هارائي	_	VERB	VM	Aspect=Perf|VerbForm=Conv	13	advcl	_	_
 18	ويٺو	ويٺو	VERB	VM	Aspect=Perf|Gender=Masc|Number=Sing|Person=3	17	compound	_	_
 19	آهيان	آهي	AUX	VAUX	Number=Sing|Person=1|Tense=Pres	17	aux	_	SpaceAfter=No
 20	.	.	PUNCT	PUNCT	_	17	punct	_	_
@@ -1579,7 +1579,7 @@
 14	خذمت	_	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	obl	_	_
 15	۾	۾	ADP	PSPL	_	14	case	_	_
 16	پيش	پيش	VERB	VM	Aspect=Imp	17	xcomp	_	_
-17	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	2	obj	_	_
+17	ڪري	ڪر	VERB	VM	Aspect=Imp|Voice=Act	2	advcl	_	_
 18	سگهان	سگهي	AUX	VAUX	Number=Sing|Person=1	17	aux	_	_
 19	ته	ته	SCONJ	CS	_	23	mark	_	_
 20	ڪهڙو	ڪهڙو	PRON	PRWH	Case=Nom|Number=Sing	23	obl	_	_
@@ -1805,7 +1805,7 @@
 40	توسان	توسان	PRON	PRP	Case=Nom|Number=Sing|Person=1	43	nsubj	_	_
 41	ڇا	ڇا	PRON	PRWH	_	43	obj	_	_
 42	ٿو	آهي	AUX	VAUX	Gender=Masc|Number=Sing|Tense=Pres	43	aux	_	_
-43	وهي	وه	VERB	VM	Aspect=Imp|Voice=Act	36	obj	_	_
+43	وهي	وه	VERB	VM	Aspect=Imp|Voice=Act	36	advcl	_	_
 44	واپري	_	VERB	VM	Aspect=Imp|Number=Sing|Person=3|Voice=Act	36	obj	_	SpaceAfter=No
 45	.	.	PUNCT	PUNCT	_	43	punct	_	_
 

--- a/not-to-release/xpos_features/sd_small_batch_labeled_2025-04-10.txt
+++ b/not-to-release/xpos_features/sd_small_batch_labeled_2025-04-10.txt
@@ -424,7 +424,7 @@
 26	نه	نه	PART	PART	_	29	mark	_	_
 27	ته	ته	SCONJ	CS	_	29	mark	_	_
 28	توکي	تو	PRON	PRP	Case=Nom|Number=Sing|Person=2	29	obj	_	_
-29	ماري	مار	VERB	VM	Aspect=Perf|VerbForm=Conv	16	obj	_	_
+29	ماري	مار	VERB	VM	Aspect=Perf|VerbForm=Conv	16	advcl	_	_
 30	ڇڏيندس	_	VERB	VMX	Aspect=Imp|Number=Sing|Person=1	29	aux	_	_
 31	،	،	PUNCT	PUNCT	_	29	punct	_	_
 
@@ -470,7 +470,7 @@
 21	ڏسجي	ڏسج	VERB	VM	Aspect=Imp|Number=Sing	12	obj	_	_
 22	؟	؟	PUNCT	PUNCT	_	21	punct	_	_
 23	ڪڙميءَ	ڪڙمي	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
-24	چيو	چئو	VERB	VM	Aspect=Perf|Number=Sing	12	obj	_	_
+24	چيو	چئو	VERB	VM	Aspect=Perf|Number=Sing	12	advcl	_	_
 25	ته	ته	SCONJ	CS	_	24	mark	_	_
 26	:	:	PUNCT	PUNCT	_	24	punct	_	_
 27	سائين	سائين	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	33	obl	_	_


### PR DESCRIPTION
Find and fix the following problem described by Prof. Rahman:

> A common pattern is that a VERB followed by SCONJ (which is a mark of relation) is wrongly in obj relation. This must be in advcl relation. If you are getting it just update obj in this pattern to advcl.
>
> This is very common pattern. Though there are other patterns as well, but once this pattern is removed we can look into the remaining ones.

![image](https://github.com/user-attachments/assets/55dc68ab-b10a-4934-a99b-6fa6b427f6de)






